### PR TITLE
Now sorting hashes so they don't jumble on every puppet run + properly printing arrays

### DIFF
--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -4,7 +4,7 @@
 #
 <% if @global_tags -%>
 [global_tags]
-<%   @global_tags.each do |key, value| -%>
+<%   @global_tags.sort.each do |key, value| -%>
   <%= key %> = "<%= value %>"
 <%   end -%>
 <% end -%>
@@ -25,11 +25,11 @@
 #
 # OUTPUTS:
 #
-<%   @outputs.each_pair do | output, options | -%>
+<%   @outputs.sort.each do | output, options | -%>
 [[outputs.<%= output %>]]
 <%      unless options == nil -%>
-<%          options.each do | option, value | -%>
-  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% else %><%= value %><% end %>
+<%          options.sort.each do | option, value | -%>
+  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%          end -%>
 <%      end -%>
 <%   end -%>
@@ -39,11 +39,11 @@
 #
 # INPUTS:
 #
-<%   @inputs.each_pair do | input, options | -%>
+<%   @inputs.sort.each do | input, options | -%>
 [[inputs.<%= input %>]]
 <%      unless options == nil -%>
-<%          options.each do | option, value | -%>
-  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% else %><%= value %><% end %>
+<%          options.sort.each do | option, value | -%>
+  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%          end -%>
 <%      end -%>
 <%   end -%>


### PR DESCRIPTION
EL6 is still on Ruby 1.8 by default, which doesn't order hashes.  It's still a valid backwards compatibility to keep in mind.  Without sorting the hashes, every time puppet runs it remakes the file and restarts the process.

Also, for some reason it didn't print out arrays in ['array'] format, but rather as a string.  Doing .is_a?(Array) and using value.inspect will force the [''] format.
