### PR TITLE
Don't require a specific repo name when manage_repo = false.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -37,11 +37,15 @@ class telegraf::install {
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',
           gpgcheck => true,
         }
+        ensure_packages(['telegraf'], {
+          'ensure'  => $::telegraf::ensure,
+          'require' =>  Yumrepo['influxdata'],
+        })
+      } else {
+        ensure_packages(['telegraf'], {
+          'ensure'  => $::telegraf::ensure,
+        })
       }
-      ensure_packages(['telegraf'], {
-        'ensure'  => $::telegraf::ensure,
-        'require' =>  Yumrepo['influxdata'],
-      })
     }
     default: {
       fail('Only RedHat, CentOS, Debian and Ubuntu are supported at this time')


### PR DESCRIPTION
If $manage_repo is true, requiring the repo by that name is fine - but if $manage_repo is false, install.pp fails at this step.  This fixed it for my environment - require the 'influxdata' repo if manage_repo, and if not, but still redhat/centos, just ensure the package and let puppet fail if it doesn't exist.
