### PR TITLE
Change validate_array($global_tags) to validate_hash($global_tags)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,7 @@ class telegraf (
   validate_bool($quiet)
   validate_hash($inputs)
   validate_hash($outputs)
-  validate_array($global_tags)
+  validate_hash($global_tags)
   validate_bool($manage_service)
   validate_bool($manage_repo)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class telegraf::params {
   $flush_jitter           = '0s'
   $debug                  = false
   $quiet                  = false
-  $global_tags            = []
+  $global_tags            = {}
   $manage_service         = true
   $manage_repo            = true
 


### PR DESCRIPTION
Tests were failing with `Failure/Error: raise Puppet::ParseError, ("#{arg.inspect} is not an Array.  It looks to be a #{arg.class}")`
