### PR TITLE
Fix acceptance tests on Debian, bump version to 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pkg
 travis.log
 .vagrant
 spec/fixtures/*
+junit

--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ Or here's a Hiera-based example (which is the recommended approach):
         username: 'telegraf'
         password: 'telegraf'
 
-To configure individual inputs, you can use `telegraf::input`
+To configure individual inputs, you can use `telegraf::input`.
 
 Example 1
 
     telegraf::input { 'my_exec':
       plugin_type => 'exec'
-      options => {
+      options     => {
         'commands'    => ['/usr/local/bin/my_input.py',],
         'name_suffix' => '_my_input',
         'data_format' => 'json',
       },
-      require => File['/usr/local/bin/my_input.py'],
+      require     => File['/usr/local/bin/my_input.py'],
     }
 
-Will create the file `/etc/telegraf/telegraf.d/my_exec.conf`
+Will create the file `/etc/telegraf/telegraf.d/my_exec.conf`:
 
     [[inputs.exec]]
       commands = ['/usr/local/bin/my_input.py']
@@ -111,7 +111,7 @@ Example 2
       },
     }
 
-Will create the file `/etc/telegraf/telegraf.d/influxdb-dc.conf`
+Will create the file `/etc/telegraf/telegraf.d/influxdb-dc.conf`:
 
     [[inputs.influxdb]]
       urls = ["http://remote-dc:8086"]
@@ -119,12 +119,12 @@ Will create the file `/etc/telegraf/telegraf.d/influxdb-dc.conf`
 Example 3
 
     telegraf::input { 'my_snmp':
-      plugin_type = 'snmp',
-      options => {
+      plugin_type => 'snmp',
+      options     => {
         'interval' => '60s',
       },
-      sections => {
-        'snmp.host' => {
+      sections    => {
+        'snmp.host'   => {
           'address'   => 'snmp_host1:161',
           'community' => 'read_only',
           'version'   => 2,
@@ -133,7 +133,7 @@ Example 3
       },
     }
 
-Will create the file `/etc/telegraf/telegraf.d/snmp.conf`
+Will create the file `/etc/telegraf/telegraf.d/snmp.conf`:
 
     [[inputs.snmp]]
       interval = "60s"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datacentred-telegraf",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": "DataCentred Ltd",
   "summary": "Configuration and management of InfluxData's Telegraf metrics collection agent",
   "license": "GPL-3.0",

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -15,8 +15,9 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
+    # Required on Debian to install from HTTPS-enabled repos, i.e InfluxData
+    on 'debian', 'apt-get -y install apt-transport-https'
     # Install module
-    # We assume the module is in auto load layout
     puppet_module_install(:source => proj_root, :module_name => 'telegraf')
     # Install dependancies
     hosts.each do |host|


### PR DESCRIPTION
This commit fixes problems with acceptance tests on Debian due to
missing support for SSL-enabled repos, bumps the version of the module
to 1.2.0, and addresses a couple of minor typos in the README.
