### PR TITLE
Fix broken package deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ There's a couple of fairly standard dependencies for this module, as follows:
 * https://github.com/puppetlabs/puppetlabs-stdlib
 * https://github.com/puppetlabs/puppetlabs-apt (on Debian / Ubuntu)
 
+*NB:* On some apt-based distributions you'll need to ensure you have support
+for TLS-enabled repos in place.  This can be achieved by installing the
+`apt-transport-https` package.
+
 ### Usage
 
 Telegraf's configuration is split into four main sections - global tags,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,6 @@ class telegraf::install {
   if $::telegraf::manage_repo {
     case $::osfamily {
       'Debian': {
-        ensure_packages(['apt-transport-https'])
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
           location => "https://repos.influxdata.com/${_operatingsystem}",
@@ -22,7 +21,6 @@ class telegraf::install {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
             'source' => 'https://repos.influxdata.com/influxdb.key',
           },
-          require  => Package['apt-transport-https'],
         }
         Class['apt::update'] -> Package['telegraf']
       }

--- a/spec/acceptance/nodesets/ubuntu1404.yml
+++ b/spec/acceptance/nodesets/ubuntu1404.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    platform: ubuntu-14.04-amd64
+    box : puppetlabs/ubuntu-14.04-64-nocm
+    box_url : https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor : vagrant
+CONFIG:
+  masterless: true
+  log_level: verbose
+  type: git

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,6 +21,9 @@ RSpec.configure do |c|
     puppet_module_install(:source => proj_root, :module_name => 'telegraf')
     # Install dependancies
     hosts.each do |host|
+      if fact('osfamily') == 'Debian'
+        on host, 'apt-get -y install apt-transport-https'
+      end
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
     end


### PR DESCRIPTION
- Revert 80f0f1c which introduced `apt-transport-https`
- Update README and relevant spec helper

Fixes #19 
