### PR TITLE
Add purge_inputs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,10 +4,6 @@
 #
 class telegraf::config inherits telegraf {
 
-  $purge = $::telegraf::params::purge
-
-  validate_bool($purge)
-
   assert_private()
 
   file { $::telegraf::config_file:
@@ -20,13 +16,4 @@ class telegraf::config inherits telegraf {
     require => Class['::telegraf::install'],
   }
 
-  if $purge {
-    tidy {
-      'purge_inputs':
-        path    => '/etc/telegraf/telegraf.d/',
-        matches => [ '*.conf' ],
-        recurse => 1,
-        rmdirs  => false,
-    }
-  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,10 @@
 #
 class telegraf::config inherits telegraf {
 
+  $purge = $::telegraf::params::purge
+
+  validate_bool($purge)
+
   assert_private()
 
   file { $::telegraf::config_file:
@@ -16,4 +20,13 @@ class telegraf::config inherits telegraf {
     require => Class['::telegraf::install'],
   }
 
+  if $purge {
+    tidy {
+      'purge_inputs':
+        path    => '/etc/telegraf/telegraf.d/',
+        matches => [ '*.conf' ],
+        recurse => 1,
+        rmdirs  => false,
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@
 #   String. State of the telegraf package. You can also specify a
 #   particular version to install.
 #
+# [*purge*]
+#   Delete inputs configs before applying new ones
+#
 # [*config_file*]
 #   String. Path to the configuration file.
 #
@@ -59,6 +62,7 @@
 #
 class telegraf (
   $ensure                 = $telegraf::params::ensure,
+  $purge                  = $telegraf::params::purge,
   $config_file            = $telegraf::params::config_file,
   $hostname               = $telegraf::params::hostname,
   $interval               = $telegraf::params::interval,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,10 @@ class telegraf::install {
 
   assert_private()
 
+  $purge = $::telegraf::params::purge
+
+  validate_bool($purge)
+
   $_operatingsystem = downcase($::operatingsystem)
 
   if $::telegraf::manage_repo {
@@ -41,5 +45,15 @@ class telegraf::install {
   }
 
   ensure_packages(['telegraf'], { ensure => $::telegraf::ensure })
+
+  if $purge {
+    tidy {
+      'purge_inputs':
+        path    => '/etc/telegraf/telegraf.d/',
+        matches => [ '*.conf' ],
+        recurse => 1,
+        rmdirs  => false,
+    }
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class telegraf::params {
 
   $ensure                 = 'present'
+  $purge                  = true
   $config_file            = '/etc/telegraf/telegraf.conf'
   $hostname               = $::hostname
   $interval               = '10s'

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -20,6 +20,7 @@ describe 'telegraf' do
           it { should contain_class('telegraf')
             .with(
               :ensure         => '0.11.1-1',
+              :purge          => true,
               :interval       => '60s',
               :flush_interval => '60s',
               :global_tags    => {
@@ -77,6 +78,7 @@ describe 'telegraf' do
           it { should contain_file('/etc/telegraf/telegraf.conf') }
           it { should contain_package('telegraf') }
           it { should contain_service('telegraf') }
+          it { should contain_tidy('purge_inputs') }
           it { should contain_yumrepo('influxdata') }
         end
       end

--- a/spec/defines/input_spec.rb
+++ b/spec/defines/input_spec.rb
@@ -66,3 +66,26 @@ describe 'telegraf::input' do
     end
   end
 end
+
+describe 'telegraf::input' do
+  let(:title) { 'my_postqueue' }
+  let(:params) {{
+    :plugin_type => 'postqueue'
+  }}
+  let(:facts) { { :osfamily => 'RedHat' } }
+  let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
+
+  describe 'configuration file /etc/telegraf/telegraf.d/my_postqueue.conf input without options or sections' do
+    it 'is declared with the correct content' do
+      should contain_file(filename).with_content(/\[\[inputs.postqueue\]\]/)
+    end
+
+    it 'requires telegraf to be installed' do
+      should contain_file(filename).that_requires('Class[telegraf::install]')
+    end
+
+    it 'notifies the telegraf daemon' do
+      should contain_file(filename).that_notifies("Class[telegraf::service]")
+    end
+  end
+end

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -1,4 +1,5 @@
 [[inputs.<%= @plugin_type %>]]
+<% if @options -%>
 <% @options.keys.sort.each do |key| -%>
 <% if @options[key].is_a?(String) -%>
   <%= key %> = "<%= @options[key] %>"
@@ -6,6 +7,7 @@
   <%= key %> = <%= @options[key].inspect %>
 <% else -%>
   <%= key %> = <%= @options[key] %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @sections -%>

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -2,6 +2,8 @@
 <% @options.keys.sort.each do |key| -%>
 <% if @options[key].is_a?(String) -%>
   <%= key %> = "<%= @options[key] %>"
+<% elsif @options[key].kind_of?(Array) -%>
+  <%= key %> = [<% @options[key].join ('", "').each do |val| %>"<%= val %>"<% end -%>]
 <% else -%>
   <%= key %> = <%= @options[key] %>
 <% end -%>
@@ -12,6 +14,8 @@
 <% @sections[key].keys.sort.each do |value| -%>
 <% if @sections[key][value].is_a?(String) -%>
   <%= value %> = "<%= @sections[key][value] %>"
+<% elsif @sections[key].kind_of?(Array) -%>
+  <%= key %> = [<% @sections[key].join ('", "').each do |val| %>"<%= val %>"<% end -%>]
 <% else -%>
   <%= value %> = <%= @sections[key][value] %>
 <% end -%>

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -3,7 +3,7 @@
 <% if @options[key].is_a?(String) -%>
   <%= key %> = "<%= @options[key] %>"
 <% elsif @options[key].kind_of?(Array) -%>
-  <%= key %> = [<% @options[key].join ('", "').each do |val| %>"<%= val %>"<% end -%>]
+  <%= key %> = <%= @options[key].inspect %>
 <% else -%>
   <%= key %> = <%= @options[key] %>
 <% end -%>
@@ -15,7 +15,7 @@
 <% if @sections[key][value].is_a?(String) -%>
   <%= value %> = "<%= @sections[key][value] %>"
 <% elsif @sections[key].kind_of?(Array) -%>
-  <%= key %> = [<% @sections[key].join ('", "').each do |val| %>"<%= val %>"<% end -%>]
+  <%= value %> = <%= @sections[key][value].inspect %>
 <% else -%>
   <%= value %> = <%= @sections[key][value] %>
 <% end -%>


### PR DESCRIPTION
Extend tests to include more telegraf::input scenarios
Add option to purge input configs, removes the need to do ensure => absent for removed inputs

Fix up the inputs.conf.erb template a little
