### PR TITLE
Update input.pp to use the $name variable

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -10,7 +10,7 @@
 #   Some inputs take multiple sections
 
 define telegraf::input (
-  $plugin_type = undef,
+  $plugin_type = $name,
   $options    = undef,
   $sections   = undef,
 ) {


### PR DESCRIPTION
The plugin_type variable should be defaulted to the name of the resource.
