### PR TITLE
Fix hiera_merge behavior

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,12 @@ class telegraf (
   validate_bool($manage_service)
   validate_bool($manage_repo)
 
+  # currently the only way how to obtain merged hashes
+  # from multiple files (`:merge_behavior: deeper` needs to be
+  # set in your `hiera.yaml`)
+  $_outputs = hiera_hash('telegraf::outputs', $outputs)
+  $_inputs = hiera_hash('telegraf::inputs', $inputs)
+
   contain ::telegraf::install
   contain ::telegraf::config
   contain ::telegraf::service

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,22 +20,19 @@ class telegraf::params {
   $manage_service         = true
   $manage_repo            = true
 
-  # currently the only way how to obtain merged hashes
-  # from multiple files (`:merge_behavior: deeper` needs to be
-  # set in your `hiera.yaml`)
-  $outputs = hiera_hash('telegraf::outputs', {
+  $outputs = {
     'influxdb'  => {
       'urls'     => [ 'http://localhost:8086' ],
       'database' => 'telegraf',
       'username' => 'telegraf',
       'password' => 'metricsmetricsmetrics',
     }
-  })
+  }
 
-  $inputs = hiera_hash('telegraf::inputs', {
+  $inputs = {
     'cpu'  => {
       'percpu'   => true,
       'totalcpu' => true,
     }
-  })
+  }
 }

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -21,11 +21,11 @@
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 
-<% if @outputs -%>
+<% if @_outputs -%>
 #
 # OUTPUTS:
 #
-<%   @outputs.sort.each do | output, options | -%>
+<%   @_outputs.sort.each do | output, options | -%>
 [[outputs.<%= output %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
@@ -35,11 +35,11 @@
 <%   end -%>
 <% end -%>
 
-<% if @inputs -%>
+<% if @_inputs -%>
 #
 # INPUTS:
 #
-<%   @inputs.sort.each do | input, options | -%>
+<%   @_inputs.sort.each do | input, options | -%>
 [[inputs.<%= input %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>


### PR DESCRIPTION
Fixes #27. This wasn't implemented correctly in #25. The `$telegraf::params::inputs` and `$telegraf::params::outputs` values are never read because they are only provided as a default value.
