### PR TITLE
Fix Debian Installer

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,7 +15,7 @@ class telegraf::install {
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
           location => "https://repos.influxdata.com/${_operatingsystem}",
-          release  => $::distcodename,
+          release  => $::lsbdistcodename,
           repos    => $::telegraf::repo_type,
           key      => {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',


### PR DESCRIPTION
The apt repository uses a non-existant fact to create the list, update
to a fact that does exist.
