### PR TITLE
add support for omit_hostname agent parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,9 @@
 # [*hostname*]
 #   String. Override default hostname used to identify this agent.
 #
+# [*omit_hostname*]
+#   Boolean. Do no set the "host" tag in the telegraf agent.
+#
 # [*interval*]
 #   String. Default data collection interval for all inputs.
 #
@@ -64,6 +67,7 @@ class telegraf (
   $ensure                 = $telegraf::params::ensure,
   $config_file            = $telegraf::params::config_file,
   $hostname               = $telegraf::params::hostname,
+  $omit_hostname          = $telegraf::params::omit_hostname,
   $interval               = $telegraf::params::interval,
   $round_interval         = $telegraf::params::round_interval,
   $metric_buffer_limit    = $telegraf::params::metric_buffer_limit,
@@ -85,6 +89,7 @@ class telegraf (
   validate_string($ensure)
   validate_string($config_file)
   validate_string($hostname)
+  validate_bool($omit_hostname)
   validate_string($interval)
   validate_bool($round_interval)
   validate_integer($metric_buffer_limit)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   String. Override default hostname used to identify this agent.
 #
 # [*omit_hostname*]
-#   Boolean. Do no set the "host" tag in the telegraf agent.
+#   Boolean. Do not set the "host" tag in the telegraf agent.
 #
 # [*interval*]
 #   String. Default data collection interval for all inputs.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class telegraf::params {
   $ensure                 = 'present'
   $config_file            = '/etc/telegraf/telegraf.conf'
   $hostname               = $::hostname
+  $omit_hostname          = false
   $interval               = '10s'
   $round_interval         = true
   $metric_buffer_limit    = '1000'

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -11,7 +11,7 @@
 
 [agent]
   hostname = "<%= @hostname %>"
-  hostname = "<%= @omit_hostname %>"
+  omit_hostname = <%= @omit_hostname %>
   interval = "<%= @interval %>"
   round_interval = <%= @round_interval %>
   metric_buffer_limit = <%= @metric_buffer_limit %>

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -11,6 +11,7 @@
 
 [agent]
   hostname = "<%= @hostname %>"
+  hostname = "<%= @omit_hostname %>"
   interval = "<%= @interval %>"
   round_interval = <%= @round_interval %>
   metric_buffer_limit = <%= @metric_buffer_limit %>


### PR DESCRIPTION
This PR adds support form `omit_hostname` parameter in the `agent` section.
