### PR TITLE
Handle testing with Puppet 4 and Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,4 @@ rvm:
   - 2.1.6
 env:
   - BEAKER_set="default"
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.0" STRICT_VARIABLES=yes
+  - BEAKER_set="default" PUPPET_INSTALL_TYPE="agent" PUPPET_INSTALL_VERSION="1.6.1"

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,12 @@
 source 'https://rubygems.org'
 
 gem 'rake'
+gem 'safe_yaml', '~> 1.0.4'
 
 group :test do
   gem "beaker"
   gem "beaker-rspec"
+  gem 'beaker-puppet_install_helper'
   gem "puppet", ENV['PUPPET_VERSION'] || ">  3.7.0"
   gem "puppetlabs_spec_helper"
   gem "rspec"

--- a/spec/acceptance/nodesets/ubuntu1604.yml
+++ b/spec/acceptance/nodesets/ubuntu1604.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-server-1604-x64:
+    platform: ubuntu-16.04-amd64
+    box : puppetlabs/ubuntu-16.04-64-nocm
+    box_url : https://vagrantcloud.com/puppetlabs/ubuntu-16.04-64-nocm
+    hypervisor : vagrant
+CONFIG:
+  masterless: true
+  log_level: verbose
+  type: git

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,11 +1,9 @@
-require 'beaker-rspec/spec_helper'
-require 'beaker-rspec/helpers/serverspec'
+require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-hosts.each do |host|
-  on 'debian', 'apt-get -y install wget'
-  # Install Puppet
-  install_puppet
-end
+on 'debian', 'apt-get -y install wget'
+
+run_puppet_install_helper
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
Add in an additional node definition for Ubuntu 16.04, and handle the
ability to test with Puppet 4.  To make this work, set the following
environment variables on your host:

```
PUPPET_INSTALL_TYPE=agent
PUPPET_INSTALL_VERSION=1.6.1
```
