### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ There's a couple of fairly standard dependencies for this module, as follows:
 for TLS-enabled repos in place.  This can be achieved by installing the
 `apt-transport-https` package.
 
+In addition, for Windows, the following dependencies must be met:
+
+* Chocolatey installed
+* [`chocolatey/chocolatey`](https://forge.puppet.com/chocolatey/chocolatey) OR [`puppetlabs/chocolatey`](https://forge.puppet.com/puppetlabs/chocolatey)
+  * **Note:** either or both of these modules can handle ensuring the install of Chocolatey.
+
 ### Usage
 
 Telegraf's configuration is split into four main sections - global tags,
@@ -162,6 +168,18 @@ Will create the file `/etc/telegraf/telegraf.d/snmp.conf`:
       version = 2
       get_oids = ["1.3.6.1.2.1.1.5"]
 
+Example 4:
+
+```puppet
+class { '::telegraf':
+    ensure              => '1.0.1',
+    hostname            => $::hostname,
+    windows_package_url => http://internal_repo:8080/chocolatey,
+}
+```
+
+Will install telegraf version 1.0.1 on Windows using an internal chocolatey repo
+
 ## Hierarchical configuration from multiple files
 
 Hiera YAML and JSON backends support [deep hash merging](https://docs.puppet.com/hiera/3.1/configuring.html#mergebehavior) which is needed for inheriting configuration from multiple files.
@@ -214,6 +232,7 @@ This module has been developed and tested against:
  * Debian 8
  * CentOS / RHEL 6
  * CentOS / RHEL 7
+ * Windows 2008, 2008 R2, 2012, 2012 R2
 
 Support for other distributions / operating systems is planned.  Feel free to assist with development in this regard!
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,16 +10,16 @@ class telegraf::config inherits telegraf {
     $::telegraf::config_file:
       ensure  => file,
       content => template('telegraf/telegraf.conf.erb'),
-      owner   => 'telegraf',
-      group   => 'telegraf',
+      owner   => $::telegraf::config_file_owner,
+      group   => $::telegraf::config_file_group,
       mode    => '0640',
       notify  => Class['::telegraf::service'],
       require => Class['::telegraf::install'],
     ;
-    $::telegraf::config_fragment_dir:
+    $::telegraf::config_folder:
       ensure  => directory,
-      owner   => 'telegraf',
-      group   => 'telegraf',
+      owner   => $::telegraf::config_file_owner,
+      group   => $::telegraf::config_file_group,
       mode    => '0750',
       purge   => $::telegraf::purge_config_fragments,
       recurse => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,14 @@
 # [*config_file*]
 #   String. Path to the configuration file.
 #
-# [*config_fragment_dir*]
-#   String. Path to the configuration fragment directory.
+# [*config_file_owner*]
+#   String. User to own the telegraf config file.
+#
+# [*config_file_group*]
+#   String. Group to own the telegraf config file.
+#
+# [*config_folder*]
+#   String. Path of additional telegraf config files.
 #
 # [*hostname*]
 #   String. Override default hostname used to identify this agent.
@@ -69,10 +75,15 @@
 # [*repo_type*]
 #   String.  Which repo (stable, unstable, nightly) to use
 #
+# [*windows_package_url*]
+#   String.  URL for windows telegraf chocolatey repo
+#
 class telegraf (
   $ensure                 = $telegraf::params::ensure,
   $config_file            = $telegraf::params::config_file,
-  $config_fragment_dir    = $telegraf::params::config_fragment_dir,
+  $config_file_owner      = $telegraf::params::config_file_owner,
+  $config_file_group      = $telegraf::params::config_file_group,
+  $config_folder          = $telegraf::params::config_folder,
   $hostname               = $telegraf::params::hostname,
   $omit_hostname          = $telegraf::params::omit_hostname,
   $interval               = $telegraf::params::interval,
@@ -91,12 +102,18 @@ class telegraf (
   $manage_repo            = $telegraf::params::manage_repo,
   $purge_config_fragments = $telegraf::params::purge_config_fragments,
   $repo_type              = $telegraf::params::repo_type,
+  $windows_package_url    = $telegraf::params::windows_package_url,
 ) inherits ::telegraf::params
 {
 
+  $service_hasstatus = $telegraf::params::service_hasstatus
+  $service_restart   = $telegraf::params::service_restart
+
   validate_string($ensure)
   validate_string($config_file)
-  validate_absolute_path($config_fragment_dir)
+  validate_string($config_file_owner)
+  validate_string($config_file_group)
+  validate_absolute_path($config_folder)
   validate_string($hostname)
   validate_bool($omit_hostname)
   validate_string($interval)
@@ -115,6 +132,9 @@ class telegraf (
   validate_bool($manage_repo)
   validate_bool($purge_config_fragments)
   validate_string($repo_type)
+  validate_string($windows_package_url)
+  validate_bool($service_hasstatus)
+  validate_string($service_restart)
 
   # currently the only way how to obtain merged hashes
   # from multiple files (`:merge_behavior: deeper` needs to be

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -27,7 +27,7 @@ define telegraf::input (
 
   Class['::telegraf::config']
   ->
-  file {"${telegraf::config_fragment_dir}/${name}.conf":
+  file {"${telegraf::config_folder}/${name}.conf":
     content => template('telegraf/input.conf.erb')
   }
   ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,12 +34,27 @@ class telegraf::install {
         }
         Yumrepo['influxdata'] -> Package['telegraf']
       }
+      'windows': {
+        # repo is not applicable to windows
+      }
       default: {
-        fail('Only RedHat, CentOS, Debian and Ubuntu are supported at this time')
+        fail('Only RedHat, CentOS, Debian, Ubuntu and Windows are supported at this time')
       }
     }
   }
 
-  ensure_packages(['telegraf'], { ensure => $::telegraf::ensure })
+  if $::osfamily == 'windows' {
+    # required to install telegraf on windows
+    require chocolatey
+
+    # package install
+    package { 'telegraf':
+      ensure   => $::telegraf::ensure,
+      provider => chocolatey,
+      source   => $::telegraf::windows_package_url,
+    }
+  } else {
+    ensure_packages(['telegraf'], { ensure => $::telegraf::ensure })
+  }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,9 +4,25 @@
 #
 class telegraf::params {
 
+  if $::osfamily == 'windows' {
+    $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
+    $config_file_owner    = 'Administrator'
+    $config_file_group    = 'Administrators'
+    $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
+    $manage_repo          = false
+    $service_hasstatus    = false
+    $service_restart      = undef
+  } else {
+    $config_file          = '/etc/telegraf/telegraf.conf'
+    $config_file_owner    = 'telegraf'
+    $config_file_group    = 'telegraf'
+    $config_folder        = '/etc/telegraf/telegraf.d'
+    $manage_repo          = true
+    $service_hasstatus    = true
+    $service_restart      = 'pkill -HUP telegraf'
+  }
+
   $ensure                 = 'present'
-  $config_file            = '/etc/telegraf/telegraf.conf'
-  $config_fragment_dir    = '/etc/telegraf/telegraf.d'
   $hostname               = $::hostname
   $omit_hostname          = false
   $interval               = '10s'
@@ -20,9 +36,9 @@ class telegraf::params {
   $quiet                  = false
   $global_tags            = {}
   $manage_service         = true
-  $manage_repo            = true
   $purge_config_fragments = false
   $repo_type              = 'stable'
+  $windows_package_url    = 'https://chocolatey.org/api/v2/'
 
   $outputs = {
     'influxdb'  => {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,9 +9,9 @@ class telegraf::service {
   if $::telegraf::manage_service {
     service { 'telegraf':
       ensure    => running,
-      hasstatus => true,
+      hasstatus => $telegraf::service_hasstatus,
       enable    => true,
-      restart   => 'pkill -HUP telegraf',
+      restart   => $telegraf::service_restart,
       require   => Class['::telegraf::config'],
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -24,6 +24,10 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [ "6", "7" ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [ "Server 2008", "Server 2008 R2", "Server 2012", "Server 2012 R2" ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This will add windows support for telegraf installation and configuration. In order to support installation of telegraf on windows, the chocolatey-chocolatey or puppet-chocolatey forge module is required.