### PR TITLE
Add support for purging unmanaged config fragments

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,14 +6,24 @@ class telegraf::config inherits telegraf {
 
   assert_private()
 
-  file { $::telegraf::config_file:
-    ensure  => file,
-    content => template('telegraf/telegraf.conf.erb'),
-    mode    => '0640',
-    owner   => 'telegraf',
-    group   => 'telegraf',
-    notify  => Class['::telegraf::service'],
-    require => Class['::telegraf::install'],
+  file {
+    default:
+      owner   => 'telegraf',
+      group   => 'telegraf',
+      notify  => Class['::telegraf::service'],
+      require => Class['::telegraf::install'],
+    ;
+    $::telegraf::config_file:
+      ensure  => file,
+      content => template('telegraf/telegraf.conf.erb'),
+      mode    => '0640',
+    ;
+    $::telegraf::config_fragment_dir:
+      ensure  => directory,
+      mode    => '0750',
+      purge   => $::telegraf::purge_config_fragments,
+      recurse => true,
+    ;
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,22 +7,24 @@ class telegraf::config inherits telegraf {
   assert_private()
 
   file {
-    default:
-      owner   => 'telegraf',
-      group   => 'telegraf',
-      notify  => Class['::telegraf::service'],
-      require => Class['::telegraf::install'],
-    ;
     $::telegraf::config_file:
       ensure  => file,
       content => template('telegraf/telegraf.conf.erb'),
+      owner   => 'telegraf',
+      group   => 'telegraf',
       mode    => '0640',
+      notify  => Class['::telegraf::service'],
+      require => Class['::telegraf::install'],
     ;
     $::telegraf::config_fragment_dir:
       ensure  => directory,
+      owner   => 'telegraf',
+      group   => 'telegraf',
       mode    => '0750',
       purge   => $::telegraf::purge_config_fragments,
       recurse => true,
+      notify  => Class['::telegraf::service'],
+      require => Class['::telegraf::install'],
     ;
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,9 @@
 # [*config_file*]
 #   String. Path to the configuration file.
 #
+# [*config_fragment_dir*]
+#   String. Path to the configuration fragment directory.
+#
 # [*hostname*]
 #   String. Override default hostname used to identify this agent.
 #
@@ -60,12 +63,16 @@
 # [*manage_repo*]
 #   Boolean.  Whether or not to manage InfluxData's repo.
 #
+# [*purge_config_fragments*]
+#   Boolean. Whether unmanaged configuration fragments should be removed.
+#
 # [*repo_type*]
 #   String.  Which repo (stable, unstable, nightly) to use
 #
 class telegraf (
   $ensure                 = $telegraf::params::ensure,
   $config_file            = $telegraf::params::config_file,
+  $config_fragment_dir    = $telegraf::params::config_fragment_dir,
   $hostname               = $telegraf::params::hostname,
   $omit_hostname          = $telegraf::params::omit_hostname,
   $interval               = $telegraf::params::interval,
@@ -82,12 +89,14 @@ class telegraf (
   $global_tags            = $telegraf::params::global_tags,
   $manage_service         = $telegraf::params::manage_service,
   $manage_repo            = $telegraf::params::manage_repo,
+  $purge_config_fragments = $telegraf::params::purge_config_fragments,
   $repo_type              = $telegraf::params::repo_type,
 ) inherits ::telegraf::params
 {
 
   validate_string($ensure)
   validate_string($config_file)
+  validate_absolute_path($config_fragment_dir)
   validate_string($hostname)
   validate_bool($omit_hostname)
   validate_string($interval)
@@ -104,6 +113,7 @@ class telegraf (
   validate_hash($global_tags)
   validate_bool($manage_service)
   validate_bool($manage_repo)
+  validate_bool($purge_config_fragments)
   validate_string($repo_type)
 
   # currently the only way how to obtain merged hashes

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -27,7 +27,7 @@ define telegraf::input (
 
   Class['::telegraf::config']
   ->
-  file {"/etc/telegraf/telegraf.d/${name}.conf":
+  file {"${telegraf::config_fragment_dir}/${name}.conf":
     content => template('telegraf/input.conf.erb')
   }
   ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class telegraf::params {
 
   $ensure                 = 'present'
   $config_file            = '/etc/telegraf/telegraf.conf'
+  $config_fragment_dir    = '/etc/telegraf/telegraf.d'
   $hostname               = $::hostname
   $omit_hostname          = false
   $interval               = '10s'
@@ -20,6 +21,7 @@ class telegraf::params {
   $global_tags            = {}
   $manage_service         = true
   $manage_repo            = true
+  $purge_config_fragments = false
   $repo_type              = 'stable'
 
   $outputs = {

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -73,6 +73,9 @@ describe 'telegraf' do
             )
           }
           it { should contain_file('/etc/telegraf/telegraf.conf') }
+          it { should contain_file('/etc/telegraf/telegraf.d')
+            .with_purge(false)
+          }
           it { should contain_package('telegraf') }
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')


### PR DESCRIPTION
As suggested by @joshuaspence in #39.

This defaults to disabled to ease migration from previous versions.

I've taken a slightly different approach to #2, in that I've decoupled the parameter names from 'inputs' since conf.d directory could foreseeably be used for outputs and filters. I'm more than happy to change the names etc if you'd prefer different ones. 

Please let me know your thoughts, and thanks for all your work on this module!