### PR TITLE
Fix failing specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 script:
   - bundle exec rake validate lint beaker
 rvm:
-  - 2.1.6
+  - 2.2.6
 env:
   - BEAKER_set="default"
   - BEAKER_set="default" PUPPET_INSTALL_TYPE="agent" PUPPET_INSTALL_VERSION="1.6.1"

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -6,13 +6,9 @@ describe 'telegraf' do
       [6,7].each do |releasenum|
         context "RedHat #{releasenum} release specifics" do
           let(:facts) {{
-            :osfamily                  => 'RedHat',
-            :architecture              => 'x86_64',
-            :kernel                    => 'Linux',
             :operatingsystem           => osfamily,
             :operatingsystemrelease    => releasenum,
             :operatingsystemmajrelease => releasenum,
-            :role                      => 'telegraf'
           }}
           it { should compile.with_all_deps }
           it { should contain_class('telegraf::config') }
@@ -81,7 +77,7 @@ describe 'telegraf' do
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')
             .with(
-              :baseurl => "https://repos.influxdata.com/rhel/#{facts[:operatingsystemmajrelease]}/#{facts[:architecture]}/stable",
+              :baseurl => "https://repos.influxdata.com/rhel/#{releasenum}/x86_64/stable",
             )
           }
 
@@ -89,7 +85,7 @@ describe 'telegraf' do
             let(:params) { {:repo_type => 'unstable' } }
             it { should contain_yumrepo('influxdata')
               .with(
-                :baseurl => "https://repos.influxdata.com/rhel/#{facts[:operatingsystemmajrelease]}/#{facts[:architecture]}/unstable",
+                :baseurl => "https://repos.influxdata.com/rhel/#{releasenum}/x86_64/unstable",
               )
             }
           end

--- a/spec/defines/input_spec.rb
+++ b/spec/defines/input_spec.rb
@@ -8,7 +8,6 @@ describe 'telegraf::input' do
       "urls" => ["http://localhost:8086",],
     },
   }}
-  let(:facts) { { :osfamily => 'RedHat' } }
   let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
 
   describe "configuration file /etc/telegraf/telegraf.d/my_influxdb.conf input" do
@@ -43,7 +42,6 @@ describe 'telegraf::input' do
       },
     },
   }}
-  let(:facts) { { :osfamily => 'RedHat' } }
   let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
 
   describe 'configuration file /etc/telegraf/telegraf.d/my_snmp.conf input with sections' do
@@ -54,7 +52,7 @@ describe 'telegraf::input' do
       should contain_file(filename).with_content(/  address = "snmp_host1:161"/)
       should contain_file(filename).with_content(/  community = "read_only"/)
       should contain_file(filename).with_content(/  get_oids = \["1.3.6.1.2.1.1.5"\]/)
-      should contain_file(filename).with_content(/  version = "2"/)
+      should contain_file(filename).with_content(/  version = 2/)
     end
 
     it 'requires telegraf to be installed' do
@@ -72,7 +70,6 @@ describe 'telegraf::input' do
   let(:params) {{
     :plugin_type => 'haproxy',
   }}
-  let(:facts) { { :osfamily => 'RedHat' } }
   let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
 
   describe 'configuration file /etc/telegraf/telegraf.d/my_haproxy.conf input with no options or sections' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,16 @@ RSpec.configure do |c|
     Puppet.features.stubs(:root? => true)
   end
 
+  c.default_facts = {
+    :osfamily                  => 'RedHat',
+    :architecture              => 'x86_64',
+    :kernel                    => 'Linux',
+    :operatingsystem           => 'RedHat',
+    :operatingsystemrelease    => 7,
+    :operatingsystemmajrelease => 7,
+    :role                      => 'telegraf'
+  }
+
   c.hiera_config = 'spec/hiera.yaml'
 
 end


### PR DESCRIPTION
This fixes some specs that had begun to fail due to changes introduced to the module since they were first written.

It makes some generic facts available by default to allow spec/defines/input_spec.rb to run, and updates the expected content of the my_snmp test to handle a previous change to templates/input.conf.erb which added support for non-string values.