### PR TITLE
Normalize Repository file for RHEL and CentOS

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,7 +26,7 @@ class telegraf::install {
       }
       'RedHat': {
         yumrepo { 'influxdata':
-          descr    => "InfluxData Repository - ${::operatingsystem) \$releasever",
+          descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
           enabled  => 1,
           baseurl  => "https://repos.influxdata.com/${_operatingsystem}/\$releasever/\$basearch/${::telegraf::repo_type}",
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,9 +26,9 @@ class telegraf::install {
       }
       'RedHat': {
         yumrepo { 'influxdata':
-          descr    => 'influxdata',
+          descr    => 'InfluxData Repository - RHEL $releasever',
           enabled  => 1,
-          baseurl  => "https://repos.influxdata.com/rhel/${::operatingsystemmajrelease}/${::architecture}/${::telegraf::repo_type}",
+          baseurl  => "https://repos.influxdata.com/${_operatingsystem}/\$releasever/\$basearch/${::telegraf::repo_type}",
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',
           gpgcheck => true,
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,11 +26,11 @@ class telegraf::install {
       }
       'RedHat': {
         yumrepo { 'influxdata':
-          descr    => 'InfluxData Repository - RHEL $releasever',
+          descr    => "InfluxData Repository - ${::operatingsystem) \$releasever",
           enabled  => 1,
           baseurl  => "https://repos.influxdata.com/${_operatingsystem}/\$releasever/\$basearch/${::telegraf::repo_type}",
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',
-          gpgcheck => true,
+          gpgcheck => 1,
         }
         Yumrepo['influxdata'] -> Package['telegraf']
       }

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -80,7 +80,7 @@ describe 'telegraf' do
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')
             .with(
-              :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/\$basearch/stable",
+              :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/stable",
             )
           }
 

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -80,7 +80,7 @@ describe 'telegraf' do
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')
             .with(
-              :baseurl => "https://repos.influxdata.com/rhel/#{releasenum}/x86_64/stable",
+              :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/\$basearch/stable",
             )
           }
 
@@ -88,7 +88,7 @@ describe 'telegraf' do
             let(:params) { {:repo_type => 'unstable' } }
             it { should contain_yumrepo('influxdata')
               .with(
-                :baseurl => "https://repos.influxdata.com/rhel/#{releasenum}/x86_64/unstable",
+                :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/unstable",
               )
             }
           end

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'telegraf' do
   context 'Supported operating systems' do
-    ['RedHat', ].each do |osfamily|
+    ['RedHat', 'CentOS'].each do |operatingsystem|
       [6,7].each do |releasenum|
-        context "RedHat #{releasenum} release specifics" do
+        context "#{osfamily} #{releasenum} release specifics" do
           let(:facts) {{
-            :operatingsystem           => osfamily,
+            :operatingsystem           => operatingsystem,
             :operatingsystemrelease    => releasenum,
             :operatingsystemmajrelease => releasenum,
           }}
@@ -80,7 +80,7 @@ describe 'telegraf' do
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')
             .with(
-              :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/stable",
+              :baseurl => "https://repos.influxdata.com/#{operatingsystem.downcase}/\$releasever/\$basearch/stable",
             )
           }
 
@@ -88,7 +88,7 @@ describe 'telegraf' do
             let(:params) { {:repo_type => 'unstable' } }
             it { should contain_yumrepo('influxdata')
               .with(
-                :baseurl => "https://repos.influxdata.com/#{Facter['::operatingsystem'].value.downcase}/\$releasever/\$basearch/unstable",
+                :baseurl => "https://repos.influxdata.com/#{operatingsystem.downcase}/\$releasever/\$basearch/unstable",
               )
             }
           end


### PR DESCRIPTION
According to the following link we could make use of `yum variables`:
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Using_Yum_Variables.html

Furthermore it might be preferable to set the `descr`  field to the value which is used on the official docs instructions:
https://www.influxdata.com/package-repository-for-linux/#centos-users

It's rather odd that they use `influxdb` as their repository name tho. Which is why I went for `influxdata` instead.