### PR TITLE
Fixes #32 and #42

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,4 +28,5 @@ class telegraf::config inherits telegraf {
     ;
   }
 
+  create_resources(::telegraf::input, $_input_plugins)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@
 # [*inputs*]
 #   Hash.  Specify input plugins and their options.
 #
+# [*input_plugins*]
+#   Hash.  Specify input plugins of the same type and their options.
+#
 # [*global_tags*]
 #   Hash.  Global tags as a key-value pair.
 #
@@ -96,6 +99,7 @@ class telegraf (
   $debug                  = $telegraf::params::debug,
   $quiet                  = $telegraf::params::quiet,
   $inputs                 = $telegraf::params::inputs,
+  $input_plugins          = $telegraf::params::input_plugins,
   $outputs                = $telegraf::params::outputs,
   $global_tags            = $telegraf::params::global_tags,
   $manage_service         = $telegraf::params::manage_service,
@@ -141,6 +145,7 @@ class telegraf (
   # set in your `hiera.yaml`)
   $_outputs = hiera_hash('telegraf::outputs', $outputs)
   $_inputs = hiera_hash('telegraf::inputs', $inputs)
+  $_input_plugins = hiera_hash('telegraf::input_plugins', $input_plugins)
 
   contain ::telegraf::install
   contain ::telegraf::config

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -27,7 +27,8 @@ define telegraf::input (
 
   Class['::telegraf::config']
   ->
-  file {"${telegraf::config_folder}/${name}.conf":
+  file {"${telegraf::config_folder}/${name}.conf ${title}":
+    path    => "${telegraf::config_folder}/${name}.conf",
     content => template('telegraf/input.conf.erb')
   }
   ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,4 +55,5 @@ class telegraf::params {
       'totalcpu' => true,
     }
   }
+  $input_plugins = {}
 }

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -1,7 +1,7 @@
 [[inputs.<%= @plugin_type %>]]
 <%      unless @options == nil -%>
 <%          @options.sort.each do | option, value | -%>
-  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+  <%= option -%> = <% value.inspect %>
 <%          end -%>
 <%      end -%>
 <% if @sections -%>
@@ -9,7 +9,7 @@
 [[inputs.<%= section %>]]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>
-  <%= suboption -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+  <%= suboption -%> = <%= value.inspect %>
 <%          end -%>
 <%      end -%>
 <%   end -%>

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -1,15 +1,15 @@
 [[inputs.<%= @plugin_type %>]]
 <%      unless @options == nil -%>
 <%          @options.sort.each do | option, value | -%>
-  <%= option -%> = <% value.inspect %>
+  <%= option -%> = <%= value.inspect %>
 <%          end -%>
 <%      end -%>
 <% if @sections -%>
 <% @sections.sort.each do |section, option| -%>
-[[inputs.<%= section %>]]
+  [<%= section %>]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>
-  <%= suboption -%> = <%= value.inspect %>
+    <%= suboption -%> = <%= value.inspect %>
 <%          end -%>
 <%      end -%>
 <%   end -%>

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -5,7 +5,7 @@
 <% if @global_tags -%>
 [global_tags]
 <%   @global_tags.sort.each do |key, value| -%>
-  <%= key %> = "<%= value %>"
+  <%= key %> = <%= value.inspect %>
 <%   end -%>
 <% end -%>
 
@@ -30,7 +30,7 @@
 [[outputs.<%= output %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
-  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+  <%= option -%> = <%= value.inspect %>
 <%          end -%>
 <%      end -%>
 <%   end -%>
@@ -44,7 +44,7 @@
 [[inputs.<%= input %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
-  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+  <%= option -%> = <%= value.inspect %>
 <%          end -%>
 <%      end -%>
 <%   end -%>


### PR DESCRIPTION
See #32 and #42 issues and commits respectively.

#32 Would require a template change to rely on ruby's `.inspect` method instead of comparing datatypes.

I guess that might *break* stringified boolean values? I'm not certain in which version of Puppet the change of string bools vs actual bools was introduced.

#42 Would make the file resource names unique and thus allow using multiple `telegraf::input` defines with the same `section` name.


*actually solve #42* Would introduce a new variable in `telegraf::init` called `input_plugins`. It would allow defining inputs which share the same name but can be defined multiple times.

