### PR TITLE
Provide the ability to disable or stop the telegraf service.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,8 @@ class telegraf (
   $purge_config_fragments = $telegraf::params::purge_config_fragments,
   $repo_type              = $telegraf::params::repo_type,
   $windows_package_url    = $telegraf::params::windows_package_url,
+  $service_enable         = $telegraf::params::service_enable,
+  $service_ensure         = $telegraf::params::service_ensure,
 ) inherits ::telegraf::params
 {
 
@@ -135,6 +137,8 @@ class telegraf (
   validate_string($windows_package_url)
   validate_bool($service_hasstatus)
   validate_string($service_restart)
+  validate_bool($service_enable)
+  validate_string($service_ensure)
 
   # currently the only way how to obtain merged hashes
   # from multiple files (`:merge_behavior: deeper` needs to be

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,8 @@ class telegraf::params {
     $config_file_group    = 'Administrators'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
     $manage_repo          = false
+    $service_enable       = true
+    $service_ensure       = running
     $service_hasstatus    = false
     $service_restart      = undef
   } else {
@@ -18,6 +20,8 @@ class telegraf::params {
     $config_file_group    = 'telegraf'
     $config_folder        = '/etc/telegraf/telegraf.d'
     $manage_repo          = true
+    $service_enable       = true
+    $service_ensure       = running
     $service_hasstatus    = true
     $service_restart      = 'pkill -HUP telegraf'
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,9 +8,9 @@ class telegraf::service {
 
   if $::telegraf::manage_service {
     service { 'telegraf':
-      ensure    => running,
+      ensure    => $telegraf::service_ensure,
       hasstatus => $telegraf::service_hasstatus,
-      enable    => true,
+      enable    => $telegraf::service_enable,
       restart   => $telegraf::service_restart,
       require   => Class['::telegraf::config'],
     }


### PR DESCRIPTION
There may be a time when a sys admin needs to _stop_ the telegraf service
on one or more machines. Let's add the ability to _control_ the
service, rather than statically enabling and starting the service.

Thanks for your work on this Puppet module!