### PR TITLE
Update repo url in install.pp for rhel machines.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class telegraf::install {
           name     => 'influxdata',
           descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
           enabled  => 1,
-          baseurl  => "https://repos.influxdata.com/${_operatingsystem}/\$releasever/\$basearch/${::telegraf::repo_type}",
+          baseurl  => "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${::telegraf::repo_type}",
           gpgkey   => 'https://repos.influxdata.com/influxdb.key',
           gpgcheck => 1,
         }


### PR DESCRIPTION
I'm not sure when the url changed, but the wrong url was causing yum to
error as it tried to update the influxdata repo.