### PR TITLE
Adding explicit support for OEL.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,7 +39,7 @@ class telegraf::install {
         # repo is not applicable to windows
       }
       default: {
-        fail('Only RedHat, CentOS, Debian, Ubuntu and Windows are supported at this time')
+        fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows are supported at this time')
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -18,6 +18,10 @@
       "operatingsystemrelease": [ "8" ]
     },
     {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [ "6", "7" ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [ "6", "7" ]
     },

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'telegraf' do
   context 'Supported operating systems' do
-    ['RedHat', 'CentOS'].each do |operatingsystem|
+    ['RedHat', 'CentOS', 'OracleLinux'].each do |operatingsystem|
       [6,7].each do |releasenum|
         context "#{osfamily} #{releasenum} release specifics" do
           let(:facts) {{


### PR DESCRIPTION
Tag 1.3.0 already works fine on OracleLinux 6/7. This just makes it clear.