### PR TITLE
Add logfile option. Fixes #52

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,9 @@
 # [*config_file*]
 #   String. Path to the configuration file.
 #
+# [*log_file*]
+#   String. Path to the log file.
+#
 # [*config_file_owner*]
 #   String. User to own the telegraf config file.
 #
@@ -85,6 +88,7 @@ class telegraf (
   $package_name           = $telegraf::params::package_name,
   $ensure                 = $telegraf::params::ensure,
   $config_file            = $telegraf::params::config_file,
+  $log_file               = $telegraf::params::log_file,
   $config_file_owner      = $telegraf::params::config_file_owner,
   $config_file_group      = $telegraf::params::config_file_group,
   $config_folder          = $telegraf::params::config_folder,
@@ -118,6 +122,7 @@ class telegraf (
   validate_string($package_name)
   validate_string($ensure)
   validate_string($config_file)
+  validate_string($log_file)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,7 @@ class telegraf::params {
 
   if $::osfamily == 'windows' {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
+    $log_file             = 'C:/Program Files/telegraf/telegraf.log'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
@@ -16,6 +17,7 @@ class telegraf::params {
     $service_restart      = undef
   } else {
     $config_file          = '/etc/telegraf/telegraf.conf'
+    $log_file             = ''
     $config_file_owner    = 'telegraf'
     $config_file_group    = 'telegraf'
     $config_folder        = '/etc/telegraf/telegraf.d'

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -19,6 +19,7 @@
   collection_jitter = "<%= @collection_jitter %>"
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"
+  logfile = "<%= @logfile %>"
   debug = <%= @debug %>
   quiet = <%= @quiet %>
 


### PR DESCRIPTION
This PR enables the configuration of the logfile option. As mentioned in #52 

For windows the logfile will be in the install folder.
On linux systems I left the parameter empty. This results in logging to STDERR ( -> journald) which is acceptable as default in my opinion. 