### PR TITLE
Support multiple output plugins of the same type

### DIFF
--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -1,0 +1,34 @@
+# == Define: telegraf::output
+#
+# A Puppet wrapper for discrete Telegraf output files
+#
+# === Parameters
+#
+# [*options*]
+#   Hash. Plugin options for use the the output template.
+#
+# [*sections*]
+#   Hash. Some outputs take multiple sections.
+#
+define telegraf::output (
+  $plugin_type = $name,
+  $options     = undef,
+  $suboptions  = undef,
+  $sections    = undef,
+) {
+  include telegraf
+
+  if $options {
+    validate_hash($options)
+  }
+
+  if $sections {
+    validate_hash($sections)
+  }
+
+  Class['::telegraf::config']
+  -> file { "${telegraf::config_folder}/output-${name}.conf":
+    content => template('telegraf/output.conf.erb'),
+  }
+  ~> Class['::telegraf::service']
+}

--- a/templates/output.conf.erb
+++ b/templates/output.conf.erb
@@ -1,0 +1,16 @@
+[[outputs.<%= @plugin_type %>]]
+<%      unless @options == nil -%>
+<%          @options.sort.each do | option, value | -%>
+  <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+<%          end -%>
+<%      end -%>
+<% if @sections -%>
+<% @suboptions.sort.each do |section, option| -%>
+  [outputs.<%= @plugin_type %>.<%= section %>]
+<%      unless option == nil -%>
+<%          option.sort.each do | suboption, value | -%>
+    <%= suboption -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+<%          end -%>
+<%      end -%>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
We need to write (replicate) the same metrics to 2 different influxdb servers but that's not possible with current implementation

This PR defines telegraf::output type which can be used to fulfill our needs.

Any comments/suggestions welcome. :-)