### PR TITLE
Fix typo in logfile parameter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'safe_yaml', '~> 1.0.4'
+gem 'metadata-json-lint'
 
 group :test do
   gem "beaker"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 # [*config_file*]
 #   String. Path to the configuration file.
 #
-# [*log_file*]
+# [*logfile*]
 #   String. Path to the log file.
 #
 # [*config_file_owner*]
@@ -88,7 +88,6 @@ class telegraf (
   $package_name           = $telegraf::params::package_name,
   $ensure                 = $telegraf::params::ensure,
   $config_file            = $telegraf::params::config_file,
-  $log_file               = $telegraf::params::log_file,
   $config_file_owner      = $telegraf::params::config_file_owner,
   $config_file_group      = $telegraf::params::config_file_group,
   $config_folder          = $telegraf::params::config_folder,
@@ -101,6 +100,7 @@ class telegraf (
   $collection_jitter      = $telegraf::params::collection_jitter,
   $flush_interval         = $telegraf::params::flush_interval,
   $flush_jitter           = $telegraf::params::flush_jitter,
+  $logfile                = $telegraf::params::logfile,
   $debug                  = $telegraf::params::debug,
   $quiet                  = $telegraf::params::quiet,
   $inputs                 = $telegraf::params::inputs,
@@ -122,7 +122,7 @@ class telegraf (
   validate_string($package_name)
   validate_string($ensure)
   validate_string($config_file)
-  validate_string($log_file)
+  validate_string($logfile)
   validate_string($config_file_owner)
   validate_string($config_file_group)
   validate_absolute_path($config_folder)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,10 +6,10 @@ class telegraf::params {
 
   if $::osfamily == 'windows' {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
-    $log_file             = 'C:/Program Files/telegraf/telegraf.log'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
+    $logfile              = 'C:/Program Files/telegraf/telegraf.log'
     $manage_repo          = false
     $service_enable       = true
     $service_ensure       = running
@@ -17,10 +17,10 @@ class telegraf::params {
     $service_restart      = undef
   } else {
     $config_file          = '/etc/telegraf/telegraf.conf'
-    $log_file             = ''
     $config_file_owner    = 'telegraf'
     $config_file_group    = 'telegraf'
     $config_folder        = '/etc/telegraf/telegraf.d'
+    $logfile              = ''
     $manage_repo          = true
     $service_enable       = true
     $service_ensure       = running


### PR DESCRIPTION
Align the name of this parameter with option as it should be in
`telegraf.conf`.

🐛 #58.