### PR TITLE
Add single_section to input plugins (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,16 +142,21 @@ Example 3:
 
 ```puppet
 telegraf::input { 'my_snmp':
-  plugin_type => 'snmp',
-  options     => {
+  plugin_type    => 'snmp',
+  options        => {
     'interval' => '60s',
   },
-  sections    => {
+  sections       => {
     'snmp.host' => {
       'address'   => 'snmp_host1:161',
       'community' => 'read_only',
       'version'   => 2,
       'get_oids'  => ['1.3.6.1.2.1.1.5',],
+    },
+  },
+  single_section => {
+    'snmp.tags' => {
+      'environment' => 'development',
     },
   },
 }
@@ -167,6 +172,9 @@ Will create the file `/etc/telegraf/telegraf.d/snmp.conf`:
       community = "read_only"
       version = 2
       get_oids = ["1.3.6.1.2.1.1.5"]
+
+    [inputs.snmp.tags]
+      environment = "development"
 
 Example 4:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,7 +164,7 @@ class telegraf (
   contain ::telegraf::config
   contain ::telegraf::service
 
-  Class['::telegraf::install'] ->
-  Class['::telegraf::config'] ->
-  Class['::telegraf::service']
+  Class['::telegraf::install']
+  -> Class['::telegraf::config']
+  -> Class['::telegraf::service']
 }

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -7,13 +7,17 @@
 # [*options*]
 #   Hash. Plugin options for use the the input template.
 #
-# [*sections*]
-#   Hash. Some inputs take multiple sections.
+# [*single_section*]
+#   Hash. Some inputs take a single unique section in [single brackets].
 #
+# [*sections*]
+#   Hash. Some inputs take multiple sections in [[double brackets]].
+
 define telegraf::input (
-  $plugin_type = $name,
-  $options     = undef,
-  $sections    = undef,
+  $plugin_type    = $name,
+  $options        = undef,
+  $single_section = undef,
+  $sections       = undef,
 ) {
   include telegraf
 
@@ -21,15 +25,17 @@ define telegraf::input (
     validate_hash($options)
   }
 
+  if $single_section {
+    validate_hash($single_section)
+  }
+
   if $sections {
     validate_hash($sections)
   }
 
   Class['::telegraf::config']
-  ->
-  file {"${telegraf::config_folder}/${name}.conf":
+  -> file {"${telegraf::config_folder}/${name}.conf":
     content => template('telegraf/input.conf.erb')
   }
-  ~>
-  Class['::telegraf::service']
+  ~> Class['::telegraf::service']
 }

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -4,7 +4,7 @@ describe 'telegraf' do
   context 'Supported operating systems' do
     ['RedHat', 'CentOS', 'OracleLinux'].each do |operatingsystem|
       [6,7].each do |releasenum|
-        context "#{osfamily} #{releasenum} release specifics" do
+        context "#{operatingsystem} #{releasenum} release specifics" do
           let(:facts) {{
             :operatingsystem           => operatingsystem,
             :operatingsystemrelease    => releasenum,
@@ -80,7 +80,7 @@ describe 'telegraf' do
           it { should contain_service('telegraf') }
           it { should contain_yumrepo('influxdata')
             .with(
-              :baseurl => "https://repos.influxdata.com/#{operatingsystem.downcase}/\$releasever/\$basearch/stable",
+              :baseurl => "https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable",
             )
           }
 
@@ -88,7 +88,7 @@ describe 'telegraf' do
             let(:params) { {:repo_type => 'unstable' } }
             it { should contain_yumrepo('influxdata')
               .with(
-                :baseurl => "https://repos.influxdata.com/#{operatingsystem.downcase}/\$releasever/\$basearch/unstable",
+                :baseurl => "https://repos.influxdata.com/rhel/\$releasever/\$basearch/unstable",
               )
             }
           end

--- a/spec/defines/input_spec.rb
+++ b/spec/defines/input_spec.rb
@@ -33,6 +33,11 @@ describe 'telegraf::input' do
     :options => {
       "interval" => "60s",
     },
+    :single_section => {
+      "snmp.tags" => {
+        "environment" => "development",
+      },
+    },
     :sections => {
       "snmp.host" => {
         "address"   => "snmp_host1:161",
@@ -48,6 +53,8 @@ describe 'telegraf::input' do
     it 'is declared with the correct content' do
       should contain_file(filename).with_content(/\[\[inputs.snmp\]\]/)
       should contain_file(filename).with_content(/  interval = "60s"/)
+      should contain_file(filename).with_content(/\[inputs.snmp.tags\]/)
+      should contain_file(filename).with_content(/  environment = "development"/)
       should contain_file(filename).with_content(/\[\[inputs.snmp.host\]\]/)
       should contain_file(filename).with_content(/  address = "snmp_host1:161"/)
       should contain_file(filename).with_content(/  community = "read_only"/)

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -14,3 +14,13 @@
 <%      end -%>
 <%   end -%>
 <% end -%>
+<% if @single_section -%>
+<% @single_section.sort.each do |section, option| -%>
+[inputs.<%= section %>]
+<%      unless option == nil -%>
+<%          option.sort.each do | suboption, value | -%>
+  <%= suboption -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
+<%          end -%>
+<%      end -%>
+<%   end -%>
+<% end -%>


### PR DESCRIPTION
Single-bracket directives are required for certain sorts of input plugin
options, e.g. setting tags on that input plugin. This adds a
single_section template and directive (via @kkzinger 's solution, ty!),
as well as tests and updated docs with an example.

Also, fixed some fatal linter issues and made the acceptance tests pass.