### PR TITLE
make package work with newer puppetlabs-apt, add support for metric batch size, and update buffer limit default to current telegraf default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,9 @@
 # [*round_interval*]
 #   Boolean. Rounds collection interval to 'interval'
 #
+# [*metric_batch_size*]
+#   Integer. Telegraf will limit each output batch to this size.
+#
 # [*metric_buffer_limit*]
 #   Integer. Cache metric_buffer_limit metrics for each output, and flush this
 #   buffer on a successful write.
@@ -98,6 +101,7 @@ class telegraf (
   $omit_hostname          = $telegraf::params::omit_hostname,
   $interval               = $telegraf::params::interval,
   $round_interval         = $telegraf::params::round_interval,
+  $metric_batch_size      = $telegraf::params::metric_batch_size,
   $metric_buffer_limit    = $telegraf::params::metric_buffer_limit,
   $flush_buffer_when_full = $telegraf::params::flush_buffer_when_full,
   $collection_jitter      = $telegraf::params::collection_jitter,
@@ -134,6 +138,7 @@ class telegraf (
   validate_bool($omit_hostname)
   validate_string($interval)
   validate_bool($round_interval)
+  validate_integer($metric_batch_size)
   validate_integer($metric_buffer_limit)
   validate_bool($flush_buffer_when_full)
   validate_string($collection_jitter)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,7 @@ class telegraf::params {
   $omit_hostname          = false
   $interval               = '10s'
   $round_interval         = true
+  $metric_batch_size      = '1000'
   $metric_buffer_limit    = '1000'
   $flush_buffer_when_full = true
   $collection_jitter      = '0s'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class telegraf::params {
   $interval               = '10s'
   $round_interval         = true
   $metric_batch_size      = '1000'
-  $metric_buffer_limit    = '1000'
+  $metric_buffer_limit    = '10000'
   $flush_buffer_when_full = true
   $collection_jitter      = '0s'
   $flush_interval         = '10s'

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": [
     { "name": "puppetlabs-stdlib", "version_requirement": ">=4.10.0 < 5.0.0" },
-    { "name": "puppetlabs-apt", "version_requirement": ">= 2.0.0 < 3.0.0" }
+    { "name": "puppetlabs-apt", "version_requirement": ">= 2.0.0 < 5.0.0" }
   ],
   "requirements": [
     { "name": "puppet", "version_requirement": "> = 3.0.0 < 5.0.0" }

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -14,6 +14,7 @@
   omit_hostname = <%= @omit_hostname %>
   interval = "<%= @interval %>"
   round_interval = <%= @round_interval %>
+  metric_batch_size = <%= @metric_batch_size %>
   metric_buffer_limit = <%= @metric_buffer_limit %>
   flush_buffer_when_full = <%= @flush_buffer_when_full %>
   collection_jitter = "<%= @collection_jitter %>"


### PR DESCRIPTION
Fixes #62 

Tested on Ubuntu 16.04. Install package just fine, so works for me :-)

Log from applying manifest:

root@citest:/home/htj# puppet apply < /etc/puppet/manifests/telegraf.pp 
Warning: /etc/puppetlabs/puppet/hiera.yaml: Use of 'hiera.yaml' version 3 is deprecated. It should be converted to version 5
   (in /etc/puppetlabs/puppet/hiera.yaml)
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::String. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/telegraf/manifests/init.pp", 118]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Absolute_Path. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/telegraf/manifests/init.pp", 123]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Bool. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/telegraf/manifests/init.pp", 125]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Integer. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/telegraf/manifests/init.pp", 128]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Stdlib::Compat::Hash. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/telegraf/manifests/init.pp", 135]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Warning: The function 'hiera_hash' is deprecated in favor of using 'lookup'. See https://docs.puppet.com/puppet/4.10/reference/deprecated_language.html
   (file & line not available)
Warning: This method is deprecated, please use the stdlib validate_legacy function, with Pattern[]. There is further documentation for validate_legacy function in the README. at ["/etc/puppetlabs/code/environments/production/modules/apt/manifests/setting.pp", 21]:
   (at /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:25:in `deprecation')
Notice: Compiled catalog for citest.sei.nordu.net in environment production in 0.63 seconds
Notice: /Stage[main]/Apt/File[preferences]/ensure: created
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/content: content changed '{md5}b9de0ac9e2c9854b1bb213e362dc4e41' to '{md5}0962d70c4ec78bbfa6f3544ae0c41974'
Notice: /Stage[main]/Telegraf::Install/Apt::Source[influxdata]/Apt::Key[Add key: 05CE15085FC09D18E99EFB22684A14CF2582E0C5 from Apt::Source influxdata]/Apt_key[Add key: 05CE15085FC09D18E99EFB22684A14CF2582E0C5 from Apt::Source influxdata]/ensure: created
Notice: /Stage[main]/Telegraf::Install/Apt::Source[influxdata]/Apt::Setting[list-influxdata]/File[/etc/apt/sources.list.d/influxdata.list]/ensure: defined content as '{md5}f12f7c5cefb1194c642d51fa6d5c09be'
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Telegraf::Install/Package[telegraf]/ensure: created
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.conf]/ensure: defined content as '{md5}7e71c17c15148745d5c77308b14742ea'
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.d]/owner: owner changed 'root' to 'telegraf'
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.d]/group: group changed 'root' to 'telegraf'
Notice: /Stage[main]/Telegraf::Config/File[/etc/telegraf/telegraf.d]/mode: mode changed '0755' to '0750'
Notice: /Stage[main]/Telegraf::Service/Service[telegraf]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 12.56 seconds
