### PR TITLE
add parameter for config file/folder mode instead of hardcoding it

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ class telegraf::config inherits telegraf {
       content => template('telegraf/telegraf.conf.erb'),
       owner   => $::telegraf::config_file_owner,
       group   => $::telegraf::config_file_group,
-      mode    => '0640',
+      mode    => $::telegraf::config_file_mode,
       notify  => Class['::telegraf::service'],
       require => Class['::telegraf::install'],
     ;
@@ -20,7 +20,7 @@ class telegraf::config inherits telegraf {
       ensure  => directory,
       owner   => $::telegraf::config_file_owner,
       group   => $::telegraf::config_file_group,
-      mode    => '0770',
+      mode    => $::telegraf::config_folder_mode,
       purge   => $::telegraf::purge_config_fragments,
       recurse => true,
       notify  => Class['::telegraf::service'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,8 @@ class telegraf (
   $config_file_owner      = $telegraf::params::config_file_owner,
   $config_file_group      = $telegraf::params::config_file_group,
   $config_folder          = $telegraf::params::config_folder,
+  $config_file_mode       = $telegraf::params::config_file_mode,
+  $config_folder_mode     = $telegraf::params::config_folder_mode,
   $hostname               = $telegraf::params::hostname,
   $omit_hostname          = $telegraf::params::omit_hostname,
   $interval               = $telegraf::params::interval,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,8 @@ class telegraf::params {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
+    $config_file_mode     = '660'
+    $config_folder_mode   = '770'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
     $logfile              = 'C:/Program Files/telegraf/telegraf.log'
     $manage_repo          = false
@@ -19,6 +21,8 @@ class telegraf::params {
     $config_file          = '/etc/telegraf/telegraf.conf'
     $config_file_owner    = 'telegraf'
     $config_file_group    = 'telegraf'
+    $config_file_mode     = '640'
+    $config_folder_mode   = '750'
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''
     $manage_repo          = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class telegraf::params {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
-    $config_file_mode     = '660'
+    $config_file_mode     = '640'
     $config_folder_mode   = '770'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
     $logfile              = 'C:/Program Files/telegraf/telegraf.log'
@@ -22,7 +22,7 @@ class telegraf::params {
     $config_file_owner    = 'telegraf'
     $config_file_group    = 'telegraf'
     $config_file_mode     = '640'
-    $config_folder_mode   = '750'
+    $config_folder_mode   = '770'
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''
     $manage_repo          = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,8 +8,8 @@ class telegraf::params {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
-    $config_file_mode     = '640'
-    $config_folder_mode   = '770'
+    $config_file_mode     = '0640'
+    $config_folder_mode   = '0770'
     $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
     $logfile              = 'C:/Program Files/telegraf/telegraf.log'
     $manage_repo          = false
@@ -21,8 +21,8 @@ class telegraf::params {
     $config_file          = '/etc/telegraf/telegraf.conf'
     $config_file_owner    = 'telegraf'
     $config_file_group    = 'telegraf'
-    $config_file_mode     = '640'
-    $config_folder_mode   = '770'
+    $config_file_mode     = '0640'
+    $config_folder_mode   = '0770'
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''
     $manage_repo          = true


### PR DESCRIPTION
The config file and folder modes currently  are hardcoded.
In our particular case, we do some additional `concat` operations in the config folder, and the result file is with mode 660 instead of 640, hence every puppet run is not converged:

```
Info: Applying configuration version '1497929241'
Notice: /Stage[main]/Profiles::Windows_install_iis_stage2/Package[notepadplusplus]/ensure: created
Notice: /Stage[main]/Telegraf::Config/File[C:/Program Files/telegraf/telegraf.conf]/mode: mode changed '0660' to '0640'
Info: /Stage[main]/Telegraf::Config/File[C:/Program Files/telegraf/telegraf.conf]: Scheduling refresh of Class[Telegraf:
:Service]
Notice: /Stage[main]/Telegraf::Config/File[C:/Program Files/telegraf/telegraf.d]/mode: mode changed '0770' to '0750'
Info: /Stage[main]/Telegraf::Config/File[C:/Program Files/telegraf/telegraf.d]: Scheduling refresh of Class[Telegraf::Se
rvice]
Notice: /Stage[main]/Profiles::Legacy_facts/File[C:\Documents and Settings\All Users\Application Data\PuppetLabs\facter\
facts.d\i2g_legacy.yaml]/ensure: defined content as '{md5}accca29b08e5b07a659c1dc32d42a6b6'
Info: Class[Telegraf::Service]: Scheduling refresh of Service[telegraf]
Notice: /Stage[main]/Telegraf::Service/Service[telegraf]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 38.43 seconds
```

So, instead of hardcoding, we can just define these as parameters, and then later override with hiera, or provide as needed.

Tested it on windows, works as expected.
The default values are preserved!
Regards