### PR TITLE
fix Puppetlint format string

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ exclude_paths = [
 
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.ignore_paths = exclude_paths
-PuppetLint.configuration.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')


### PR DESCRIPTION
%{linenumber} is deprecated puppet-lint format syntax; it completely breaks 'rake lint' output.

```%{path}:%{linenumber}:%{check}:%{KIND}:%{message}```
becomes
```manifests/input.pp:36:arrow_on_right_operand_line:WARNING:arrow should be on the right operand's line```