### PR TITLE
Agent configuration - update and removal of certain options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,15 +38,11 @@
 # [*round_interval*]
 #   Boolean. Rounds collection interval to 'interval'
 #
-# [*metric_batch_size*]
-#   Integer. Telegraf will limit each output batch to this size.
+# [*metric_batch_size*] Integer. The maximum batch size to allow to
+#   accumulate before sending a flush to the configured outputs
 #
-# [*metric_buffer_limit*]
-#   Integer. Cache metric_buffer_limit metrics for each output, and flush this
-#   buffer on a successful write.
-#
-# [*flush_buffer_when_full*]
-#   Boolean. Flush buffer whenever full, regardless of flush_interval
+# [*metric_buffer_limit*] Integer.  The absolute maximum number of
+#   metrics that will accumulate before metrics are dropped.
 #
 # [*collection_jitter*]
 #   String.  Sleep for a random time within jitter before collecting.
@@ -103,7 +99,6 @@ class telegraf (
   $round_interval         = $telegraf::params::round_interval,
   $metric_batch_size      = $telegraf::params::metric_batch_size,
   $metric_buffer_limit    = $telegraf::params::metric_buffer_limit,
-  $flush_buffer_when_full = $telegraf::params::flush_buffer_when_full,
   $collection_jitter      = $telegraf::params::collection_jitter,
   $flush_interval         = $telegraf::params::flush_interval,
   $flush_jitter           = $telegraf::params::flush_jitter,
@@ -140,7 +135,6 @@ class telegraf (
   validate_bool($round_interval)
   validate_integer($metric_batch_size)
   validate_integer($metric_buffer_limit)
-  validate_bool($flush_buffer_when_full)
   validate_string($collection_jitter)
   validate_string($flush_interval)
   validate_string($flush_jitter)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,6 @@ class telegraf::params {
   $round_interval         = true
   $metric_batch_size      = '1000'
   $metric_buffer_limit    = '10000'
-  $flush_buffer_when_full = true
   $collection_jitter      = '0s'
   $flush_interval         = '10s'
   $flush_jitter           = '0s'

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -17,9 +17,11 @@ describe 'telegraf' do
           it { should contain_class('telegraf::service') }
           it { should contain_class('telegraf')
             .with(
-              :ensure         => '0.11.1-1',
-              :interval       => '60s',
-              :flush_interval => '60s',
+              :ensure              => '1.3.5-1',
+              :interval            => '60s',
+              :metric_batch_size   => '1000',
+              :metric_buffer_limit => '10000',
+              :flush_interval      => '60s',
               :global_tags    => {
                 "dc"   => "dc",
                 "env"  => "production",

--- a/spec/hieradata/test/telegraf.yaml
+++ b/spec/hieradata/test/telegraf.yaml
@@ -1,5 +1,5 @@
 ---
-telegraf::ensure: "0.11.1-1"
+telegraf::ensure: "1.3.5-1"
 telegraf::interval: "60s"
 telegraf::flush_interval: "60s"
 telegraf::global_tags:

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -16,7 +16,6 @@
   round_interval = <%= @round_interval %>
   metric_batch_size = <%= @metric_batch_size %>
   metric_buffer_limit = <%= @metric_buffer_limit %>
-  flush_buffer_when_full = <%= @flush_buffer_when_full %>
   collection_jitter = "<%= @collection_jitter %>"
   flush_interval = "<%= @flush_interval %>"
   flush_jitter = "<%= @flush_jitter %>"


### PR DESCRIPTION
Update the comment around `metric_batch_size` and
`metric_buffer_limit` to reflect revised behaviour.

Also remove deprecated parameter `flush_buffer_when_full`.

cf. https://github.com/influxdata/telegraf/blob/master/CHANGELOG.md#v013-2016-05-11

Partially addresses #71.