### PR TITLE
Skip empty hiera hashes, more flexible hiera hierarchy

### DIFF
--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -45,9 +45,6 @@
 # INPUTS:
 #
 <%   @_inputs.sort.each do | input, options | -%>
-<%if options.nil? or options == 'undef' -%>
-<% next -%>
-<% end -%>
 [[inputs.<%= input %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -28,7 +28,7 @@
 # OUTPUTS:
 #
 <%   @_outputs.sort.each do | output, options | -%>
-<%if options.empty? -%>
+<%if options.empty? or options == 'undef' -%>
 <% next -%>
 <% end -%>
 [[outputs.<%= output %>]]
@@ -45,7 +45,7 @@
 # INPUTS:
 #
 <%   @_inputs.sort.each do | input, options | -%>
-<%if options.nil? -%>
+<%if options.nil? or options == 'undef' -%>
 <% next -%>
 <% end -%>
 [[inputs.<%= input %>]]

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -28,6 +28,9 @@
 # OUTPUTS:
 #
 <%   @_outputs.sort.each do | output, options | -%>
+<%if options.empty? -%>
+<% next -%>
+<% end -%>
 [[outputs.<%= output %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>
@@ -42,6 +45,9 @@
 # INPUTS:
 #
 <%   @_inputs.sort.each do | input, options | -%>
+<%if options.nil? -%>
+<% next -%>
+<% end -%>
 [[inputs.<%= input %>]]
 <%      unless options == nil -%>
 <%          options.sort.each do | option, value | -%>


### PR DESCRIPTION
Hi,
Since we use hiera_hash, it would be useful to be able to skip certain hashe if wanted.
Here is a conrcete example:

common.yaml:
telegraf::inputs:
    cpu:
telegraf::outputs:
    kafka:
        brokers:
            - "kafka01:9092"
        topic: "%{::metrics_topic}"

telegrafconsumer.yaml:
telegraf::inputs: 
    kafka_consumer: 
        topics: 
            - 'telegrafcommon' 
        brokers: 
            - 'kafka01:9092'   
telegraf::outputs: 
    prometheus_client: 
        listen: ':9126'
        expiration_interval: '180s'


Normaly with hiera hash the two keys 'kafka' and "prometheus_client" will get merged for output. The same will happen with the two intput keys. This is problematic, because it creates a problem with how telegraf works (and even if it worked without errors and it does not due to a key mix up, we would be pushing the same data do kafka, at the same time exporting it to prometheus first time from system, second time when we consume it from kafka and export it yet again).

Now if we added:
telegraf::outputs: 
    kafka: {}


and with the fix in the erb template, we will be able to skip adding this output.


