### PR TITLE
Fix: input/output files are missing correct permissions

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,9 +18,9 @@ class telegraf::config inherits telegraf {
     ;
     $::telegraf::config_folder:
       ensure  => directory,
-      owner   => $::telegraf::config_file_owner,
-      group   => $::telegraf::config_file_group,
-      mode    => '0770',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0775',
       purge   => $::telegraf::purge_config_fragments,
       recurse => true,
       notify  => Class['::telegraf::service'],

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -15,7 +15,11 @@ define telegraf::input (
 
   Class['::telegraf::config']
   -> file {"${telegraf::config_folder}/${name}.conf":
-    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'inputs'=>{'${plugin_type}'=>@options}}) %>")
+    ensure  => file,
+    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'inputs'=>{'${plugin_type}'=>@options}}) %>"),
+    owner   => $::telegraf::config_file_owner,
+    group   => $::telegraf::config_file_group,
+    mode    => '0640',
   }
   ~> Class['::telegraf::service']
 }

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -15,7 +15,11 @@ define telegraf::output (
 
   Class['::telegraf::config']
   -> file {"${telegraf::config_folder}/${name}.conf":
-    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'outputs'=>{'${plugin_type}'=>@options}}) %>")
+    ensure  => file,
+    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'outputs'=>{'${plugin_type}'=>@options}}) %>"),
+    owner   => $::telegraf::config_file_owner,
+    group   => $::telegraf::config_file_group,
+    mode    => '0640',
   }
   ~> Class['::telegraf::service']
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class telegraf::params {
     $service_restart      = undef
   } else {
     $config_file          = '/etc/telegraf/telegraf.conf'
-    $config_file_owner    = 'telegraf'
+    $config_file_owner    = 'root'
     $config_file_group    = 'telegraf'
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''


### PR DESCRIPTION
Since some input plugins contain sensitive data (like credentials),
they should also be protected by stricter file permissions.