### PR TITLE
Allow input/output sections to be added as 2-element array

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -30,7 +30,9 @@ define telegraf::input (
   }
 
   if $sections {
-    validate_hash($sections)
+    unless is_array($sections) or is_hash($sections) {
+      fail("'sections' must be a hash or an array")
+    }
   }
 
   Class['::telegraf::config']

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -23,7 +23,9 @@ define telegraf::output (
   }
 
   if $sections {
-    validate_hash($sections)
+    unless is_array($sections) or is_hash($sections) {
+      fail("'sections' must be a hash or an array")
+    }
   }
 
   Class['::telegraf::config']

--- a/templates/input.conf.erb
+++ b/templates/input.conf.erb
@@ -4,8 +4,8 @@
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%          end -%>
 <%      end -%>
-<% if @sections -%>
-<% @sections.sort.each do |section, option| -%>
+<% if @sections.is_a?(Hash) or @sections.is_a?(Array) -%>
+<% @sections.instance_eval { is_a?(Hash) ? sort : self }.each do |section, option| -%>
 [[inputs.<%= section %>]]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>

--- a/templates/output.conf.erb
+++ b/templates/output.conf.erb
@@ -5,7 +5,7 @@
 <%          end -%>
 <%      end -%>
 <% if @sections -%>
-<% @suboptions.sort.each do |section, option| -%>
+<% @sections.sort.each do |section, option| -%>
   [outputs.<%= @plugin_type %>.<%= section %>]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>

--- a/templates/output.conf.erb
+++ b/templates/output.conf.erb
@@ -4,8 +4,8 @@
   <%= option -%> = <% if value.is_a?(String) %>"<%= value %>"<% elsif value.is_a?(Array) %><%= value.inspect %><% else %><%= value %><% end %>
 <%          end -%>
 <%      end -%>
-<% if @sections -%>
-<% @sections.sort.each do |section, option| -%>
+<% if @sections.is_a?(Hash) or @sections.is_a?(Array) -%>
+<% @sections.instance_eval { is_a?(Hash) ? sort : self }.each do |section, option| -%>
   [outputs.<%= @plugin_type %>.<%= section %>]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>


### PR DESCRIPTION
Plugins in Telegraf allow for wildly different configuration styles, making use of the TOML configuration language features.

One of these features is the ability to specify arrays of tables and even nesting them. This is for example used by the `inputs.snmp` plugin to specify multiple SNMP queries and their associated special casing of certain SNMP values. For example:

```toml
[[inputs.snmp]]
  agents = [ "sw0-0.example.com:161", "sw0-1.example.com:161", "sw0-2.example.com:161" ]
  version = 2
  interval = "60s"

[[inputs.snmp.table]]
  ## auto populate table's fields using the MIB
  oid = "IF-MIB::ifTable"

[[inputs.snmp.table.field]]
  oid = "IF-MIB::ifType"
  is_tag = true

[[inputs.snmp.table.field]]
  oid = "IF-MIB::ifDescr"
  is_tag = true

[[inputs.snmp.table.field]]
  oid = "IF-MIB::ifPhysAddress"
  is_tag = true

[[inputs.snmp.table]]
  ## auto populate table's fields using the MIB
  oid = "IF-MIB::ifXTable"

[[inputs.snmp.table.field]]
  oid = "IF-MIB::ifName"
  is_tag = true

[[inputs.snmp.table.field]]
  oid = "IF-MIB::ifAlias"
  is_tag = true
```

Having only support for one instance of a section name and also sorting these makes it impossible to use Telegraf plugins like the SNMP one correctly.

Therefore this commit introduces the ability to alternatively specify the sections as a 2-element array in the format of` [<section name>, { option => value, other_option => value }]`.