### PR TITLE
Fixing output template and definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ telegraf::outputs:
     password: 'telegraf'
 ```
 
-`telegraf::inputs` accepts a hash of any inputs that you'd like to configure. However, you can also optionally define individual inputs using the `telegraf::input` type - this suits installations where, for example, a core module sets the defaults and other modules import it.
+`telegraf::inputs` accepts a hash of any inputs that you'd like to configure. However, you can also optionally define individual inputs and outputs using the `telegraf::input` and `telegraf::output` types respectively - this suits installations where, for example, a core module sets the defaults and other modules import it.
 
 Example 1:
 
@@ -187,6 +187,25 @@ class { '::telegraf':
 ```
 
 Will install telegraf version 1.0.1 on Windows using an internal chocolatey repo
+
+Example 5:
+
+```puppet
+telegraf::output { 'influxdb_1':
+  plugin_type => 'influxdb',
+  options     => {
+    'urls'       => [ "http://server1.example.com:8086" ],
+    'tagexclude' => [ 'influxdb_database' ],
+  },
+  sections    => {
+     'tagpass' => {
+       'influxdb_database' => [ 'server1' ],
+     },
+  },
+}
+```
+
+Will create an InfluxDB output that only gets sent data that has the tag `influxdb_database` with value `server1`.
 
 ## Hierarchical configuration from multiple files
 

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -13,7 +13,6 @@
 define telegraf::output (
   $plugin_type = $name,
   $options     = undef,
-  $suboptions  = undef,
   $sections    = undef,
 ) {
   include telegraf

--- a/spec/defines/output_spec.rb
+++ b/spec/defines/output_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'telegraf::output' do
+  let(:title) { 'my_influxdb' }
+  let(:params) {{
+    :plugin_type => 'influxdb',
+    :options => {
+      "urls" => ["http://localhost:8086",],
+    },
+    :sections => { 'tagpass' => { 'addatag' => ['woof'] } },
+  }}
+  let(:filename) { "/etc/telegraf/telegraf.d/output-#{title}.conf" }
+
+  describe "configuration file /etc/telegraf/telegraf.d/output-my_influxdb.conf output" do
+    it 'is declared with the correct content' do
+      should contain_file(filename).with_content(/\[\[outputs\.influxdb\]\]/)
+      should contain_file(filename).with_content(/  urls = \["http:\/\/localhost:8086"\]/)
+      should contain_file(filename).with_content(/  \[outputs\.influxdb\.tagpass\]/)
+      should contain_file(filename).with_content(/    addatag = \["woof"\]/)
+    end
+
+    it 'requires telegraf to be installed' do
+      should contain_file(filename).that_requires('Class[telegraf::install]')
+    end
+
+    it 'notifies the telegraf daemon' do
+      should contain_file(filename).that_notifies("Class[telegraf::service]")
+    end
+  end
+end

--- a/templates/output.conf.erb
+++ b/templates/output.conf.erb
@@ -5,7 +5,7 @@
 <%          end -%>
 <%      end -%>
 <% if @sections -%>
-<% @suboptions.sort.each do |section, option| -%>
+<% @sections.sort.each do |section, option| -%>
   [outputs.<%= @plugin_type %>.<%= section %>]
 <%      unless option == nil -%>
 <%          option.sort.each do | suboption, value | -%>


### PR DESCRIPTION
The telegraf::outputs template and type is broken - the Defined Type validates $sections as a hash, but the template appears to treat this like a boolean and then do a Hash loop over $suboptions instead.  I've scrapped $suboptions and gone with a consistent working $sections parameter. Also added tests and example docs.