### PR TITLE
Adding support for custom repo location url.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,9 @@
 #
 # [*manage_repo*]
 #   Boolean.  Whether or not to manage InfluxData's repo.
+
+# [*repo_location*]
+#   String. Alternate repo location. E.g. an interal mirror.
 #
 # [*install_options*]
 #   String or Array. Additional options to pass when installing package
@@ -111,6 +114,7 @@ class telegraf (
   $global_tags            = $telegraf::params::global_tags,
   $manage_service         = $telegraf::params::manage_service,
   $manage_repo            = $telegraf::params::manage_repo,
+  $repo_location          = $telegraf::params::repo_location,
   $purge_config_fragments = $telegraf::params::purge_config_fragments,
   $repo_type              = $telegraf::params::repo_type,
   $windows_package_url    = $telegraf::params::windows_package_url,
@@ -146,6 +150,7 @@ class telegraf (
   validate_hash($global_tags)
   validate_bool($manage_service)
   validate_bool($manage_repo)
+  validate_string($repo_location)
   validate_bool($purge_config_fragments)
   validate_string($repo_type)
   validate_string($windows_package_url)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,12 +14,12 @@ class telegraf::install {
       'Debian': {
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
-          location => "https://repos.influxdata.com/${_operatingsystem}",
+          location => "${::telegraf::repo_location}${_operatingsystem}",
           release  => $::lsbdistcodename,
           repos    => $::telegraf::repo_type,
           key      => {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
-            'source' => 'https://repos.influxdata.com/influxdb.key',
+            'source' => "${::telegraf::repo_location}influxdb.key",
           },
         }
         Class['apt::update'] -> Package[$::telegraf::package_name]
@@ -29,8 +29,8 @@ class telegraf::install {
           name     => 'influxdata',
           descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
           enabled  => 1,
-          baseurl  => "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${::telegraf::repo_type}",
-          gpgkey   => 'https://repos.influxdata.com/influxdb.key',
+          baseurl  => "${::telegraf::repo_location}rhel/\$releasever/\$basearch/${::telegraf::repo_type}",
+          gpgkey   => '${::telegraf::repo_location}influxdb.key',
           gpgcheck => 1,
         }
         Yumrepo['influxdata'] -> Package[$::telegraf::package_name]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class telegraf::params {
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''
     $manage_repo          = true
+    $repo_location        = 'https://repos.influxdata.com/'
     $service_enable       = true
     $service_ensure       = running
     $service_hasstatus    = true


### PR DESCRIPTION
Given I required a custom repo location to point to my own, internal mirror, i figured this might be a usual addition for others. The module will still default to the Influx Data repo if no custom location is specified.