### PR TITLE
Updates for version 2.0 of this module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ rvm:
   - 2.2.6
 env:
   - BEAKER_set="default"
-  - BEAKER_set="default" PUPPET_INSTALL_TYPE="agent" PUPPET_INSTALL_VERSION="1.6.1"
+  - BEAKER_set="default" PUPPET_INSTALL_TYPE="agent" PUPPET_INSTALL_VERSION="1.6.2"

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Alex Simenduev <shamil.si@gmail.com>
 Ashton Davis <contact@adavis.me>
 Asif Shaikh <ripclawffb@users.noreply.github.com>
+Christian Becker <christian@dabecka.de>
 Cosmo Petrich <cosmopetrich@users.noreply.github.com>
 doomnuggets <doomnuggets@users.noreply.github.com>
 Gerold Katzinger <gerold@katzinger.info>
@@ -8,16 +9,19 @@ Henrik Thostrup Jensen <thostrup@gmail.com>
 James Glenn <thedonkdonk@gmail.com>
 Jessica <mxjessie@users.noreply.github.com>
 Joshua Spence <josh@joshuaspence.com>
-Joshua-Snapp <jksnapp@gmail.com>
+Joshua Snapp <jksnapp@gmail.com>
 Karolis Labrencis <karolis@labrencis.lt>
 Luke Swithenbank <swithenbank.luke@gmail.com>
 Mark McKinstry <mmckinst@users.noreply.github.com>
 Maxime Devalland <maxime@devalland.com>
 Mohammed Naser <mnaser@vexxhost.com>
 nexecook <ecook@nexcess.net>
-Nick Jones <nick.jones@datacentred.co.uk>
-Simon <spjmurray@yahoo.co.uk>
+Nick Jones <nick@dischord.org>
+nrdmn <n+github@nirf.de>
+Sandra Thieme <thieme.sandra@gmail.com>
+Simon Murray <spjmurray@yahoo.co.uk>
 Stuart Fox <sfox@xmatters.com>
 Stuart Fox <stuart@1000-clouds.ca>
 Sébastien <sebastien.nahelou@gmail.com>
+Tim Raphael <raphael.timothy@gmail.com>
 Tomas Barton <barton.tomas@gmail.com>

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'beaker'
   gem 'beaker-rspec'
   gem 'beaker-puppet_install_helper'
-  gem 'puppet', ENV['PUPPET_VERSION'] || '>  3.7.0'
+  gem 'puppet', ENV['PUPPET_VERSION'] || '>  4.0.0'
   gem 'puppetlabs_spec_helper'
   gem 'rspec'
   gem 'rspec-puppet'

--- a/README.md
+++ b/README.md
@@ -253,9 +253,14 @@ telegraf::inputs:
 
 ## Limitations
 
+The latest version (2.0) of this module requires Puppet 4 or newer.  If you're looking for support under Puppet 3.x, then you'll want to make use of [an older release](https://github.com/yankcrime/puppet-telegraf/releases/tag/1.5.0).
+
+Furthermore, the introduction of toml-rb means that Ruby 1.9 or newer is also a requirement.
+
 This module has been developed and tested against:
 
  * Ubuntu 14.04
+ * Ubuntu 16.04
  * Debian 8
  * CentOS / RHEL 6
  * CentOS / RHEL 7

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,18 +50,18 @@ class telegraf::params {
   $windows_package_url    = 'https://chocolatey.org/api/v2/'
 
   $outputs = {
-    'influxdb'  => {
+    'influxdb'  => [{
       'urls'     => [ 'http://localhost:8086' ],
       'database' => 'telegraf',
       'username' => 'telegraf',
       'password' => 'metricsmetricsmetrics',
-    }
+    }]
   }
 
   $inputs = {
-    'cpu'  => {
+    'cpu'  => [{
       'percpu'   => true,
       'totalcpu' => true,
-    }
+    }]
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "datacentred-telegraf",
-  "version": "1.5.0",
+  "name": "yankcrime-telegraf",
+  "version": "2.0.0",
   "author": "Nick Jones",
   "summary": "Configuration and management of InfluxData's Telegraf metrics collection agent",
   "license": "GPL-3.0",
@@ -12,6 +12,10 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [ "14.04" ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [ "16.04" ]
     },
     {
       "operatingsystem": "Debian",
@@ -39,6 +43,6 @@
     { "name": "puppetlabs-apt", "version_requirement": ">= 2.0.0 < 5.0.0" }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": "> = 3.0.0 < 5.0.0" }
+    { "name": "puppet", "version_requirement": "> = 4.0.0 < 5.0.0" }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,7 +1,7 @@
 HOSTS:
-  ubuntu-14.04:
-    platform: ubuntu-14.04-x64
-    image: ubuntu:14.04
+  ubuntu-16.04:
+    platform: ubuntu-16.04-x64
+    image: ubuntu:16.04
     hypervisor: docker
     docker_preserve_image: true
 CONFIG:


### PR DESCRIPTION
This commit updates information related to version 2.0 of this module, including changes to the README.

Puppet 4 is now the minimum version required.

It explicitly states support for Ubuntu 16.04 as this is the default SUT for acceptance testing.

It also includes an unrelated but necessary fix called out by @sparr in PR #80.