### PR TITLE
remove plugin_type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,8 +16,8 @@ Mark McKinstry <mmckinst@users.noreply.github.com>
 Maxime Devalland <maxime@devalland.com>
 Mohammed Naser <mnaser@vexxhost.com>
 nexecook <ecook@nexcess.net>
+Nick Erdmann <n@nirf.de>
 Nick Jones <nick@dischord.org>
-nrdmn <n+github@nirf.de>
 Sandra Thieme <thieme.sandra@gmail.com>
 Simon Murray <spjmurray@yahoo.co.uk>
 Stuart Fox <sfox@xmatters.com>

--- a/README.md
+++ b/README.md
@@ -98,10 +98,8 @@ telegraf::inputs:
   exec:
     - commands:
         - who | wc -l
-  exec-uptime:
     - commands:
         - cat /proc/uptime | awk '{print $1}'
-      plugin_type: exec
   mem: [{}]
   io: [{}]
   net: [{}]

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -38,13 +38,14 @@ describe 'telegraf' do
                 }],
                 "diskio"      => [{}],
                 "kernel"      => [{}],
-                "exec"        => [{
-                  "commands" => ['who | wc -l'],
-                }],
-                "exec-uptime" => [{
-                  "commands"    => ["cat /proc/uptime | awk '{print $1}'"],
-                  "plugin_type" => 'exec',
-                }],
+                "exec"        => [
+                  {
+                    "commands" => ['who | wc -l'],
+                  },
+                  {
+                    "commands"    => ["cat /proc/uptime | awk '{print $1}'"],
+                  }
+                ],
                 "mem"         => [{}],
                 "net"         => [{
                   "interfaces" => ['eth0'],

--- a/spec/hieradata/test/telegraf.yaml
+++ b/spec/hieradata/test/telegraf.yaml
@@ -21,10 +21,8 @@ telegraf::inputs:
   exec:
     - commands:
         - who | wc -l
-  exec-uptime:
     - commands:
         - cat /proc/uptime | awk '{print $1}'
-      plugin_type: exec
   mem: [{}]
   net:
     - interfaces:

--- a/templates/telegraf.conf.erb
+++ b/templates/telegraf.conf.erb
@@ -28,38 +28,12 @@
 #
 # OUTPUTS:
 #
-<% require 'toml-rb'
-
-@_outputs.sort.each do |key, values|
-  @new_values = {}
-  values[0].each do |k, v|
-    if k == 'plugin_type' then
-      key = v
-    else
-      @new_values[k] = v
-    end
-  end
-  @new_output = {key=>Array.new().push(@new_values)} -%>
-<%= TomlRB.dump({'outputs'=>@new_output}) %>
-<% end -%>
+<%= require 'toml-rb'; TomlRB.dump({'outputs'=>@_outputs}) %>
 <% end -%>
 
 <% if @_inputs -%>
 #
 # INPUTS:
 #
-<% require 'toml-rb'
-
-@_inputs.sort.each do |key, values|
-  @new_values = {}
-  values[0].each do |k, v|
-    if k == 'plugin_type' then
-      key = v
-    else
-      @new_values[k] = v
-    end
-  end
-  @new_input = {key=>Array.new().push(@new_values)} -%>
-<%= TomlRB.dump({'inputs'=>@new_input}) %>
-<% end -%>
+<%= require 'toml-rb'; TomlRB.dump({'inputs'=>@_inputs}) %>
 <% end -%>


### PR DESCRIPTION
This PR removes the plugin_type feature in #80 because it is redundant and because its current implementation breaks when there are no inputs or outputs.