### PR TITLE
Move configuration of lookup merge behavior into Hiera lookup_options.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Mohammed Naser <mnaser@vexxhost.com>
 nexecook <ecook@nexcess.net>
 Nick Erdmann <n@nirf.de>
 Nick Jones <nick@dischord.org>
+Robert Baumstark <robbaum@nait.ca>
 Sandra Thieme <thieme.sandra@gmail.com>
 Simon Murray <spjmurray@yahoo.co.uk>
 Stuart Fox <sfox@xmatters.com>

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,10 @@
+---
+lookup_options:
+  telegraf::inputs:
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+  telegraf::outputs:
+    merge:
+      strategy: deep
+      merge_hash_arrays: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: "Defaults"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,13 +129,11 @@ class telegraf (
 
   $_outputs = lookup({
     name          => 'telegraf::outputs',
-    default_value => $outputs,
-    merge         => deep
+    default_value => $outputs
   })
   $_inputs = lookup({
     name          => 'telegraf::inputs',
-    default_value => $inputs,
-    merge         => deep,
+    default_value => $inputs
   })
 
   contain ::telegraf::install


### PR DESCRIPTION
This fixes my issue #98 in a way that provides a (I think) sane default, and allows easy per-user overrides.  With the basics setup, this could also be the base of moving all of the default values from params.pp into a few yaml files.

My inputs are very simple and have no problems also being merged this way - but its possible for more complicated setups that the inputs should stay with normal deep merge without the 'merge_hash_arrays' enabled by default. 