### PR TITLE
Move $repo_location out of if condition to fix windows support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,6 @@ class telegraf::params {
     $config_folder        = '/etc/telegraf/telegraf.d'
     $logfile              = ''
     $manage_repo          = true
-    $repo_location        = 'https://repos.influxdata.com/'
     $service_enable       = true
     $service_ensure       = running
     $service_hasstatus    = true
@@ -47,6 +46,7 @@ class telegraf::params {
   $manage_service         = true
   $purge_config_fragments = false
   $repo_type              = 'stable'
+  $repo_location          = 'https://repos.influxdata.com/'
   $windows_package_url    = 'https://chocolatey.org/api/v2/'
 
   $outputs = {


### PR DESCRIPTION
Because of "String  $repo_location" in ::telegraf, puppet runs on windows clients fail with $repo_location cant be undef. Therefore set $repo_location outside of the windows if condition.