### PR TITLE
Add workaround for Amazon Linux repo location issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 script:
   - bundle exec rake validate lint beaker
 rvm:
-  - 2.2.6
+  - "2.4"
 env:
   - BEAKER_set="default"
   - BEAKER_set="default" PUPPET_INSTALL_TYPE="agent" PUPPET_INSTALL_VERSION="1.6.2"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -25,11 +25,16 @@ class telegraf::install {
         Class['apt::update'] -> Package[$::telegraf::package_name]
       }
       'RedHat': {
+        if $_operatingsystem == 'amazon' {
+            $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${::telegraf::repo_type}"
+        } else {
+            $_baseurl = "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${::telegraf::repo_type}"
+        }
         yumrepo { 'influxdata':
           name     => 'influxdata',
           descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
           enabled  => 1,
-          baseurl  => "${::telegraf::repo_location}rhel/\$releasever/\$basearch/${::telegraf::repo_type}",
+          baseurl  => $_baseurl,
           gpgkey   => "${::telegraf::repo_location}influxdb.key",
           gpgcheck => 1,
         }


### PR DESCRIPTION
As per https://github.com/influxdata/influxdb/issues/5035, Amazon Linux
sets the yum $releasever variable to "latest", which means that standard
RedHat repo configuration won't work. The suggested workaround in the
issue above is to hardcode the release version to 6 on Amazon Linux.

There is an open issue with Telegraf to fix packaging for Amazon Linux
(among others): https://github.com/influxdata/influxdb/issues/6454.
However, given that it's been open over two years now, I'm not holding
my breath.