### PR TITLE
Various tidying and refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ To get started, Telegraf can be installed with a very basic configuration by
 just including the class:
 
 ```puppet
-include ::telegraf
+include telegraf
 ```
 
 However, to customise your configuration you'll want to do something like the following:
 
 ```puppet
-class { '::telegraf':
+class { 'telegraf':
     hostname => $::hostname,
     outputs  => {
         'influxdb' => [
@@ -201,7 +201,7 @@ Will create the file `/etc/telegraf/telegraf.d/snmp.conf`:
 Example 4:
 
 ```puppet
-class { '::telegraf':
+class { 'telegraf':
     ensure              => '1.0.1',
     hostname            => $::hostname,
     windows_package_url => http://internal_repo:8080/chocolatey,

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ However, to customise your configuration you'll want to do something like the fo
 
 ```puppet
 class { 'telegraf':
-    hostname => $::hostname,
+    hostname => $facts['hostname'],
     outputs  => {
         'influxdb' => [
             {
-                'urls'     => [ "http://influxdb0.${::domain}:8086", "http://influxdb1.${::domain}:8086" ],
+                'urls'     => [ "http://influxdb0.${facts['domain']}:8086", "http://influxdb1.${facts['domain']}:8086" ],
                 'database' => 'telegraf',
                 'username' => 'telegraf',
                 'password' => 'metricsmetricsmetrics',
@@ -203,7 +203,7 @@ Example 4:
 ```puppet
 class { 'telegraf':
     ensure              => '1.0.1',
-    hostname            => $::hostname,
+    hostname            => $facts['hostname'],
     windows_package_url => http://internal_repo:8080/chocolatey,
 }
 ```

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,24 +7,24 @@ class telegraf::config inherits telegraf {
   assert_private()
 
   file {
-    $::telegraf::config_file:
+    $telegraf::config_file:
       ensure  => file,
       content => template('telegraf/telegraf.conf.erb'),
-      owner   => $::telegraf::config_file_owner,
-      group   => $::telegraf::config_file_group,
+      owner   => $telegraf::config_file_owner,
+      group   => $telegraf::config_file_group,
       mode    => '0640',
-      notify  => Class['::telegraf::service'],
-      require => Class['::telegraf::install'],
+      notify  => Class['telegraf::service'],
+      require => Class['telegraf::install'],
     ;
-    $::telegraf::config_folder:
+    $telegraf::config_folder:
       ensure  => directory,
-      owner   => $::telegraf::config_file_owner,
-      group   => $::telegraf::config_file_group,
+      owner   => $telegraf::config_file_owner,
+      group   => $telegraf::config_file_group,
       mode    => '0770',
-      purge   => $::telegraf::purge_config_fragments,
+      purge   => $telegraf::purge_config_fragments,
       recurse => true,
-      notify  => Class['::telegraf::service'],
-      require => Class['::telegraf::install'],
+      notify  => Class['telegraf::service'],
+      require => Class['telegraf::install'],
     ;
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,26 +6,20 @@ class telegraf::config inherits telegraf {
 
   assert_private()
 
-  file {
-    $telegraf::config_file:
-      ensure  => file,
-      content => template('telegraf/telegraf.conf.erb'),
-      owner   => $telegraf::config_file_owner,
-      group   => $telegraf::config_file_group,
-      mode    => '0640',
-      notify  => Class['telegraf::service'],
-      require => Class['telegraf::install'],
-    ;
-    $telegraf::config_folder:
-      ensure  => directory,
-      owner   => $telegraf::config_file_owner,
-      group   => $telegraf::config_file_group,
-      mode    => '0770',
-      purge   => $telegraf::purge_config_fragments,
-      recurse => true,
-      notify  => Class['telegraf::service'],
-      require => Class['telegraf::install'],
-    ;
+  file { $telegraf::config_file:
+    ensure  => file,
+    content => template('telegraf/telegraf.conf.erb'),
+    owner   => $telegraf::config_file_owner,
+    group   => $telegraf::config_file_group,
+    mode    => '0640',
+  }
+  file { $telegraf::config_folder:
+    ensure  => directory,
+    owner   => $telegraf::config_file_owner,
+    group   => $telegraf::config_file_group,
+    mode    => '0770',
+    purge   => $telegraf::purge_config_fragments,
+    recurse => true,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,5 +144,5 @@ class telegraf (
 
   Class['telegraf::install']
   -> Class['telegraf::config']
-  -> Class['telegraf::service']
+  ~> Class['telegraf::service']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,7 +121,7 @@ class telegraf (
   Boolean $service_enable         = $telegraf::params::service_enable,
   String  $service_ensure         = $telegraf::params::service_ensure,
   Array   $install_options        = $telegraf::params::install_options,
-) inherits ::telegraf::params
+) inherits telegraf::params
 {
 
   $service_hasstatus = $telegraf::params::service_hasstatus
@@ -138,11 +138,11 @@ class telegraf (
     merge         => deep,
   })
 
-  contain ::telegraf::install
-  contain ::telegraf::config
-  contain ::telegraf::service
+  contain telegraf::install
+  contain telegraf::config
+  contain telegraf::service
 
-  Class['::telegraf::install']
-  -> Class['::telegraf::config']
-  -> Class['::telegraf::service']
+  Class['telegraf::install']
+  -> Class['telegraf::config']
+  -> Class['telegraf::service']
 }

--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -8,8 +8,8 @@
 #   List. Plugin options for use in the input template.
 
 define telegraf::input (
-  String                $plugin_type = $name,
-  Variant[Undef, Array] $options     = [],
+  String $plugin_type = $name,
+  Array  $options     = [],
 ) {
   include telegraf
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,15 +7,15 @@ class telegraf::install {
 
   assert_private()
 
-  $_operatingsystem = downcase($::operatingsystem)
+  $_operatingsystem = downcase($facts['operatingsystem'])
 
   if $telegraf::manage_repo {
-    case $::osfamily {
+    case $facts['osfamily'] {
       'Debian': {
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
           location => "${telegraf::repo_location}${_operatingsystem}",
-          release  => $::lsbdistcodename,
+          release  => $facts['lsbdistcodename'],
           repos    => $telegraf::repo_type,
           key      => {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
@@ -32,7 +32,7 @@ class telegraf::install {
         }
         yumrepo { 'influxdata':
           name     => 'influxdata',
-          descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
+          descr    => "InfluxData Repository - ${facts['operatingsystem']} \$releasever",
           enabled  => 1,
           baseurl  => $_baseurl,
           gpgkey   => "${telegraf::repo_location}influxdb.key",
@@ -49,7 +49,7 @@ class telegraf::install {
     }
   }
 
-  if $::osfamily == 'windows' {
+  if $facts['osfamily'] == 'windows' {
     # required to install telegraf on windows
     require chocolatey
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,36 +9,36 @@ class telegraf::install {
 
   $_operatingsystem = downcase($::operatingsystem)
 
-  if $::telegraf::manage_repo {
+  if $telegraf::manage_repo {
     case $::osfamily {
       'Debian': {
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
-          location => "${::telegraf::repo_location}${_operatingsystem}",
+          location => "${telegraf::repo_location}${_operatingsystem}",
           release  => $::lsbdistcodename,
-          repos    => $::telegraf::repo_type,
+          repos    => $telegraf::repo_type,
           key      => {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',
-            'source' => "${::telegraf::repo_location}influxdb.key",
+            'source' => "${telegraf::repo_location}influxdb.key",
           },
         }
-        Class['apt::update'] -> Package[$::telegraf::package_name]
+        Class['apt::update'] -> Package[$telegraf::package_name]
       }
       'RedHat': {
         if $_operatingsystem == 'amazon' {
-            $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${::telegraf::repo_type}"
+            $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${telegraf::repo_type}"
         } else {
-            $_baseurl = "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${::telegraf::repo_type}"
+            $_baseurl = "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${telegraf::repo_type}"
         }
         yumrepo { 'influxdata':
           name     => 'influxdata',
           descr    => "InfluxData Repository - ${::operatingsystem} \$releasever",
           enabled  => 1,
           baseurl  => $_baseurl,
-          gpgkey   => "${::telegraf::repo_location}influxdb.key",
+          gpgkey   => "${telegraf::repo_location}influxdb.key",
           gpgcheck => 1,
         }
-        Yumrepo['influxdata'] -> Package[$::telegraf::package_name]
+        Yumrepo['influxdata'] -> Package[$telegraf::package_name]
       }
       'windows': {
         # repo is not applicable to windows
@@ -54,14 +54,14 @@ class telegraf::install {
     require chocolatey
 
     # package install
-    package { $::telegraf::package_name:
-      ensure          => $::telegraf::ensure,
+    package { $telegraf::package_name:
+      ensure          => $telegraf::ensure,
       provider        => chocolatey,
-      source          => $::telegraf::windows_package_url,
-      install_options => $::telegraf::install_options,
+      source          => $telegraf::windows_package_url,
+      install_options => $telegraf::install_options,
     }
   } else {
-    ensure_packages([$::telegraf::package_name], { ensure => $::telegraf::ensure, install_options => $::telegraf::install_options })
+    ensure_packages([$telegraf::package_name], { ensure => $telegraf::ensure, install_options => $telegraf::install_options })
   }
 
 }

--- a/manifests/output.pp
+++ b/manifests/output.pp
@@ -8,8 +8,8 @@
 #   List. Plugin options for use in the output template.
 
 define telegraf::output (
-  String                $plugin_type = $name,
-  Variant[Undef, Array] $options     = undef,
+  String          $plugin_type = $name,
+  Optional[Array] $options     = undef,
 ) {
   include telegraf
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 #
 class telegraf::params {
 
-  if $::osfamily == 'windows' {
+  if $facts['osfamily'] == 'windows' {
     $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
     $config_file_owner    = 'Administrator'
     $config_file_group    = 'Administrators'
@@ -32,7 +32,7 @@ class telegraf::params {
   $package_name           = 'telegraf'
   $ensure                 = 'present'
   $install_options        = []
-  $hostname               = $::hostname
+  $hostname               = $facts['hostname']
   $omit_hostname          = false
   $interval               = '10s'
   $round_interval         = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,7 +12,6 @@ class telegraf::service {
       hasstatus => $telegraf::service_hasstatus,
       enable    => $telegraf::service_enable,
       restart   => $telegraf::service_restart,
-      require   => Class['telegraf::config'],
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,13 +6,13 @@ class telegraf::service {
 
   assert_private()
 
-  if $::telegraf::manage_service {
+  if $telegraf::manage_service {
     service { 'telegraf':
       ensure    => $telegraf::service_ensure,
       hasstatus => $telegraf::service_hasstatus,
       enable    => $telegraf::service_enable,
       restart   => $telegraf::service_restart,
-      require   => Class['::telegraf::config'],
+      require   => Class['telegraf::config'],
     }
   }
 }


### PR DESCRIPTION
* Stop using relative class/variable names
* Remove duplicate resource relationships
* Use `facts` hash instead of topscope variables
* Don't use `Variant[Undef, Array]`