### PR TITLE
Add defined type for telegraf::processor to define processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,50 @@ Will create the file `/etc/telegraf/telegraf.d/snmp.conf`:
 
 Example 4:
 
+Outputs, Processors and Aggregators are available in the same way:
+
+```puppet
+telegraf::output { 'my_influxdb':
+  plugin_type => 'influxdb',
+  options     => [
+    {
+      'urls'     => [ "http://influxdb.example.come:8086"],
+      'database' => 'telegraf',
+      'username' => 'telegraf',
+      'password' => 'metricsmetricsmetrics',
+    }
+  ]
+}
+
+telegraf::processor { 'my_regex':
+  plugin_type => 'regex',
+  options     => [
+    {
+      tags => [
+        {
+          key         => 'foo',
+          pattern     => String(/^a*b+\d$/),
+          replacement => 'c${1}d',
+        }
+      ]
+    }
+  ]
+}
+
+telegraf::aggregator { 'my_basicstats':
+  plugin_type => 'basicstats',
+  options     => [
+    {
+      period        => '30s',
+      drop_original => false,
+    },
+  ],
+}
+
+```
+
+Example 5:
+
 ```puppet
 class { 'telegraf':
     ensure              => '1.0.1',

--- a/manifests/aggregator.pp
+++ b/manifests/aggregator.pp
@@ -1,0 +1,21 @@
+# == Define: telegraf::aggregator
+#
+# A Puppet wrapper for discrete Telegraf aggregator files
+#
+# === Parameters
+#
+# [*options*]
+#   List. Plugin options for use in the aggregator template.
+
+define telegraf::aggregator (
+  String          $plugin_type = $name,
+  Optional[Array] $options     = undef,
+) {
+  include telegraf
+
+  file {"${telegraf::config_folder}/${name}.conf":
+    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'aggregators'=>{'${plugin_type}'=>@options}}) %>"),
+    require => Class['telegraf::config'],
+    notify  => Class['telegraf::service'],
+  }
+}

--- a/manifests/processor.pp
+++ b/manifests/processor.pp
@@ -1,0 +1,21 @@
+# == Define: telegraf::processor
+#
+# A Puppet wrapper for discrete Telegraf processor files
+#
+# === Parameters
+#
+# [*options*]
+#   List. Plugin options for use in the processor template.
+
+define telegraf::processor (
+  String          $plugin_type = $name,
+  Optional[Array] $options     = undef,
+) {
+  include telegraf
+
+  file {"${telegraf::config_folder}/${name}.conf":
+    content => inline_template("<%= require 'toml-rb'; TomlRB.dump({'processors'=>{'${plugin_type}'=>@options}}) %>"),
+    require => Class['telegraf::config'],
+    notify  => Class['telegraf::service'],
+  }
+}

--- a/spec/defines/aggregator_spec.rb
+++ b/spec/defines/aggregator_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+
+describe 'telegraf::aggregator' do
+  on_supported_os(facterversion: '3.6').each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'my_basicstats' do
+        let(:title) { 'my_basicstats' }
+        let(:params) do
+          {
+            plugin_type: 'basicstats',
+            options: [
+              { 
+                'period'        => '30s',
+                'drop_original' => false,
+              }
+            ]
+          }
+        end
+
+        case facts[:kernel]
+        when 'windows'
+          let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        else
+          let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
+        end
+
+        describe 'configuration file /etc/telegraf/telegraf.d/my_basicstats.conf aggregator' do
+          it 'is declared with the correct content' do
+            is_expected.to contain_file(filename).with_content(%r{\[\[aggregators.basicstats\]\]})
+            is_expected.to contain_file(filename).with_content(%r{period = "30s"})
+            is_expected.to contain_file(filename).with_content(%r{drop_original = false})
+          end
+
+          it 'requires telegraf to be installed' do
+            is_expected.to contain_file(filename).that_requires('Class[telegraf::install]')
+          end
+
+          it 'notifies the telegraf daemon' do
+            is_expected.to contain_file(filename).that_notifies('Class[telegraf::service]')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/aggregator_spec.rb
+++ b/spec/defines/aggregator_spec.rb
@@ -13,9 +13,9 @@ describe 'telegraf::aggregator' do
           {
             plugin_type: 'basicstats',
             options: [
-              { 
+              {
                 'period'        => '30s',
-                'drop_original' => false,
+                'drop_original' => false
               }
             ]
           }

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -13,12 +13,12 @@ describe 'telegraf::processor' do
           {
             plugin_type: 'regex',
             options: [
-              { 
+              {
                 'tags' => [
                   {
                     'key'         => 'foo',
-                    'pattern'     => /^a*b+\d$/.source,
-                    'replacement' => 'c${1}d',
+                    'pattern'     => %r{^a*b+\d$}.source,
+                    'replacement' => 'c${1}d'
                   }
                 ]
               }
@@ -50,7 +50,7 @@ describe 'telegraf::processor' do
           end
         end
       end
-      
+
       context 'my_enum' do
         let(:title) { 'my_enum' }
         let(:params) do
@@ -65,7 +65,7 @@ describe 'telegraf::processor' do
                     'value_mappings' => {
                       'green' => 1,
                       'amber' => 2,
-                      'red'   => 3,
+                      'red'   => 3
                     }
                   }
                 ]

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -1,0 +1,107 @@
+require 'spec_helper'
+
+describe 'telegraf::processor' do
+  on_supported_os(facterversion: '3.6').each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'my_regex' do
+        let(:title) { 'my_regex' }
+        let(:params) do
+          {
+            plugin_type: 'regex',
+            options: [
+              { 
+                'tags' => [
+                  {
+                    'key'         => 'foo',
+                    'pattern'     => /^a*b+\d$/.source,
+                    'replacement' => 'c${1}d',
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        case facts[:kernel]
+        when 'windows'
+          let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        else
+          let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
+        end
+
+        describe 'configuration file /etc/telegraf/telegraf.d/my_regex.conf processor' do
+          it 'is declared with the correct content' do
+            is_expected.to contain_file(filename).with_content(%r{\[\[processors.regex\]\]})
+            is_expected.to contain_file(filename).with_content(%r{key = "foo"})
+            is_expected.to contain_file(filename).with_content(%r{pattern = "\^a\*b\+\\\\d\$"})
+            is_expected.to contain_file(filename).with_content(%r{replacement = "c\$\{1\}d"})
+          end
+
+          it 'requires telegraf to be installed' do
+            is_expected.to contain_file(filename).that_requires('Class[telegraf::install]')
+          end
+
+          it 'notifies the telegraf daemon' do
+            is_expected.to contain_file(filename).that_notifies('Class[telegraf::service]')
+          end
+        end
+      end
+      
+      context 'my_enum' do
+        let(:title) { 'my_enum' }
+        let(:params) do
+          {
+            plugin_type: 'enum',
+            options: [
+              {
+                'mapping' => [
+                  {
+                    'field'          => 'status',
+                    'dest'           => 'status_code',
+                    'value_mappings' => {
+                      'green' => 1,
+                      'amber' => 2,
+                      'red'   => 3,
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        end
+
+        case facts[:kernel]
+        when 'windows'
+          let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        else
+          let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
+        end
+
+        describe 'configuration file /etc/telegraf/telegraf.d/my_enum.conf processor with sections' do
+          it 'is declared with the correct content' do
+            is_expected.to contain_file(filename).with_content(%r{\[\[processors.enum\]\]})
+            is_expected.to contain_file(filename).with_content(%r{\[\[processors.enum.mapping\]\]})
+            is_expected.to contain_file(filename).with_content(%r{field = "status"})
+            is_expected.to contain_file(filename).with_content(%r{dest = "status_code"})
+            is_expected.to contain_file(filename).with_content(%r{\[processors.enum.mapping.value_mappings\]})
+            is_expected.to contain_file(filename).with_content(%r{green = 1})
+            is_expected.to contain_file(filename).with_content(%r{amber = 2})
+            is_expected.to contain_file(filename).with_content(%r{red = 3})
+          end
+
+          it 'requires telegraf to be installed' do
+            is_expected.to contain_file(filename).that_requires('Class[telegraf::install]')
+          end
+
+          it 'notifies the telegraf daemon' do
+            is_expected.to contain_file(filename).that_notifies('Class[telegraf::service]')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
This PR simply adds a `telegraf::processor` defined type which is analogous to the `telegraf::input` and `telegraf::output` defined types. You can use it to e.g. define a regex processor:

```puppet
telegraf::processor { 'regex':
  options => [
    {
      namepass => ['nginx_requests'],
      tags     => [
        {
          key         => 'resp_code',
          pattern     => String(/^(\d)\d\d$/),
          replacement => '${1}xx',
        }
      ],
      fields   => [
        {
          key         => 'request',
          pattern     => String(/^/api(?P<method>/[\w/]+)\S*/),
          replacement => '${method}',
          result_key  => 'method',
        },
        {
          key         => 'request',
          pattern     => String(/.*category=(\w+).*/),
          replacement => '${1}',
          result_key  => 'search_category',
        },
      ],
    },
  ],
}
```
