### PR TITLE
Update puppetlabs-stdlib dependency to allow 6.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">=5.0.0 < 6.0.0"
+      "version_requirement": ">=5.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
#### Pull Request (PR) description

This commit updates the dependency on puppetlabs-stdlib to allow
version 6.x of the module to be used.

#### This Pull Request (PR) fixes the following issues

N/A
