### PR TITLE
Revert "Move $repo_location out of if condition to fix windows support"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class telegraf::params {
     $config_folder_mode   = '0770'
     $logfile              = ''
     $manage_repo          = true
+    $repo_location        = 'https://repos.influxdata.com/'
     $service_enable       = true
     $service_ensure       = running
     $service_hasstatus    = true
@@ -49,7 +50,6 @@ class telegraf::params {
   $manage_service         = true
   $purge_config_fragments = false
   $repo_type              = 'stable'
-  $repo_location          = 'https://repos.influxdata.com/'
   $windows_package_url    = 'https://chocolatey.org/api/v2/'
 
   $outputs = {


### PR DESCRIPTION
Reverts voxpupuli/puppet-telegraf#100 because that broke complication. Original issue has been fixed in d694f1c16d0ce2e78c1827f83d0bea0f0ebb430e.