### PR TITLE
Added support for Raspbian

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,9 +10,14 @@ class telegraf::install {
   if $telegraf::manage_repo {
     case $facts['os']['family'] {
       'Debian': {
+        if $facts['os']['name'] == 'Raspbian' {
+          $distro = $facts['os']['family'].downcase
+        } else {
+          $distro = $facts['os']['name'].downcase
+        }
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
-          location => "${telegraf::repo_location}${facts['os']['name'].downcase}",
+          location => "${telegraf::repo_location}${distro}",
           release  => $facts['os']['distro']['codename'],
           repos    => $telegraf::repo_type,
           key      => {

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,7 @@
       "operatingsystem": "Raspbian",
       "operatingsystemrelease": [
         "8",
+        "9",
         "10"
       ]
     },
@@ -30,6 +31,7 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8",
+        "9",
         "10"
       ]
     },

--- a/metadata.json
+++ b/metadata.json
@@ -20,9 +20,17 @@
       ]
     },
     {
+      "operatingsystem": "Raspbian",
+      "operatingsystemrelease": [
+        "8",
+        "10"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "10"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Sets the distro to Debian for Raspbian when subscribing to the influxdb repo.

#### This Pull Request (PR) fixes the following issues

Raspbian is a drop replacement for Debian - it uses an identical package/repo structure.  The current code causes the influxdb download to fail as they do not have Raspbian as an OS, but Debian can be used directly.
