### PR TITLE
Fixing support for 5.5 agents on Debian

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,10 +10,15 @@ class telegraf::install {
   if $telegraf::manage_repo {
     case $facts['os']['family'] {
       'Debian': {
+        if $facts.dig('os','distro','codename') {
+          $release = $facts['os']['distro']['codename']
+        } else {
+          $release = $facts['os']['lsb']['codename']
+        }
         apt::source { 'influxdata':
           comment  => 'Mirror for InfluxData packages',
           location => "${telegraf::repo_location}${facts['os']['name'].downcase}",
-          release  => $facts['os']['distro']['codename'],
+          release  => $release,
           repos    => $telegraf::repo_type,
           key      => {
             'id'     => '05CE15085FC09D18E99EFB22684A14CF2582E0C5',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,7 +34,7 @@ class telegraf::params {
   $package_name           = 'telegraf'
   $ensure                 = 'present'
   $install_options        = []
-  $hostname               = $facts['networking']['hostname']
+  $hostname               = $trusted['hostname']
   $omit_hostname          = false
   $interval               = '10s'
   $round_interval         = true


### PR DESCRIPTION
#### Pull Request (PR) description
I have some Debian 8 systems that are stuck on 5.5 due to the old ruby and there is no AIO agent for that platform.  These were broken due to facts not resolving the same with facter 2.5.6.  Also, the v 6 agent is unusable on some Debian 10 systems as they have very low memory, but 5.5 works ok.

#### This Pull Request (PR) fixes the following issues
Fixes compilation on Debian systems with puppet 5.5.17 and facter 2.5.6.
