### PR TITLE
Changed Assign repo->package even when manage_repo=false on Debian+Re…

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,13 +49,12 @@ class telegraf::install {
         }
       }
       Yumrepo['influxdata'] -> Package[$telegraf::package_name]
-      }
-      'windows': {
-        # repo is not applicable to windows
-      }
-      default: {
-        fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows repoisitories are supported at this time')
-      }
+    }
+    'windows': {
+      # repo is not applicable to windows
+    }
+    default: {
+      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows repoisitories are supported at this time')
     }
   }
 
@@ -100,7 +99,7 @@ class telegraf::install {
         fail('Only Suse archives are supported at this time')
       }
     }
-
+  }
 
   if $facts['os']['family'] == 'windows' {
     # required to install telegraf on windows

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,9 +6,9 @@
 class telegraf::install {
   assert_private()
 
-  if $telegraf::manage_repo {
-    case $facts['os']['family'] {
-      'Debian': {
+  case $facts['os']['family'] {
+    'Debian': {
+      if $telegraf::manage_repo {
         if $facts['os']['name'] == 'Raspbian' {
           $distro = $facts['os']['family'].downcase
         } else {
@@ -29,9 +29,11 @@ class telegraf::install {
             'source' => "${telegraf::repo_location}influxdb.key",
           },
         }
-        Class['apt::update'] -> Package[$telegraf::package_name]
       }
-      'RedHat': {
+      Class['apt::update'] -> Package[$telegraf::package_name]
+    }
+    'RedHat': {
+      if $telegraf::manage_repo {
         if $facts['os']['name'] == 'Amazon' {
           $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${telegraf::repo_type}"
         } else {
@@ -45,7 +47,8 @@ class telegraf::install {
           gpgkey   => "${telegraf::repo_location}influxdb.key",
           gpgcheck => 1,
         }
-        Yumrepo['influxdata'] -> Package[$telegraf::package_name]
+      }
+      Yumrepo['influxdata'] -> Package[$telegraf::package_name]
       }
       'windows': {
         # repo is not applicable to windows
@@ -97,7 +100,7 @@ class telegraf::install {
         fail('Only Suse archives are supported at this time')
       }
     }
-  }
+
 
   if $facts['os']['family'] == 'windows' {
     # required to install telegraf on windows

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,17 +50,8 @@ class telegraf::install {
       }
       Yumrepo['influxdata'] -> Package[$telegraf::package_name]
     }
-    'windows': {
-      # repo is not applicable to windows
-    }
-    default: {
-      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows repoisitories are supported at this time')
-    }
-  }
-
-  if $telegraf::manage_archive {
-    case $facts['os']['family'] {
-      'Suse': {
+    'Suse': {
+      if $telegraf::manage_archive {
         file { $telegraf::archive_install_dir:
           ensure => directory,
         }
@@ -95,9 +86,12 @@ class telegraf::install {
           group  => $telegraf::config_file_group,
         }
       }
-      default: {
-        fail('Only Suse archives are supported at this time')
-      }
+    }
+    'windows': {
+      # repo is not applicable to windows
+    }
+    default: {
+      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows repositories and Suse archives are supported at this time')
     }
   }
 

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -126,6 +126,76 @@ describe 'telegraf' do
           }
         end
       end
+
+      describe 'manage repo' do
+        let(:pre_condition) do
+          'class {"telegraf": manage_repo => true}'
+        end
+
+        it do
+          is_expected.to compile.with_all_deps
+          case facts[:osfamily]
+          when 'Debian'
+            is_expected.to contain_apt__source('influxdata')
+            is_expected.to contain_class('apt::update').that_comes_before('Package[telegraf]')
+            is_expected.to contain_package('telegraf')
+          when 'RedHat'
+            is_expected.to contain_yumrepo('influxdata').that_comes_before('Package[telegraf]')
+            is_expected.to contain_package('telegraf')
+          end
+        end
+      end
+
+      describe 'do not manage repo on debian' do
+        let(:pre_condition) do
+          [
+            'class {"telegraf": manage_repo => false}',
+            'class {"apt": }',
+          ]
+        end
+
+        it do
+          case facts[:osfamily]
+          when 'Debian'
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_package('telegraf')
+            is_expected.to contain_class('apt::update')
+          end
+        end
+      end
+
+      describe 'do not manage repo on RedHat' do
+        let(:pre_condition) do
+          [
+            'class {"telegraf": manage_repo => false}',
+            'yumrepo {"influxdata": }',
+          ]
+        end
+
+        it do
+          case facts[:osfamily]
+          when 'RedHat'
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_package('telegraf')
+          end
+        end
+      end
+
+      describe 'do not manage repo on windows' do
+        let(:pre_condition) do
+          [
+            'class {"telegraf": manage_repo => false}',
+          ]
+        end
+
+        it do
+          case facts[:osfamily]
+          when 'windows'
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_package('telegraf')
+          end
+        end
+      end
     end
   end
 end

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -150,7 +150,7 @@ describe 'telegraf' do
         let(:pre_condition) do
           [
             'class {"telegraf": manage_repo => false}',
-            'class {"apt": }',
+            'class {"apt": }'
           ]
         end
 
@@ -168,7 +168,7 @@ describe 'telegraf' do
         let(:pre_condition) do
           [
             'class {"telegraf": manage_repo => false}',
-            'yumrepo {"influxdata": }',
+            'yumrepo {"influxdata": }'
           ]
         end
 
@@ -184,7 +184,7 @@ describe 'telegraf' do
       describe 'do not manage repo on windows' do
         let(:pre_condition) do
           [
-            'class {"telegraf": manage_repo => false}',
+            'class {"telegraf": manage_repo => false}'
           ]
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
This changes the repository installation to retain the relation between package repository and package even when the repository is not managed by the module.

#### This Pull Request (PR) fixes the following issues

This fixes use issues caused by missing dependency when e.g. using other modules to handle InfluxData packages like InfluxDB, Chronograf or Kapacitor and Telegraf is not managing the repository itself.