### PR TITLE
move relationship between package and repo into code block where repo is managed

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,8 +99,8 @@ class telegraf::install {
             'source' => "${telegraf::repo_location}influxdb.key",
           },
         }
+        Class['apt::update'] -> Package[$telegraf::package_name]
       }
-      Class['apt::update'] -> Package[$telegraf::package_name]
     }
     'RedHat': {
       if $telegraf::manage_repo {
@@ -117,8 +117,8 @@ class telegraf::install {
           gpgkey   => "${telegraf::repo_location}influxdb.key",
           gpgcheck => 1,
         }
+        Yumrepo['influxdata'] -> Package[$telegraf::package_name]
       }
-      Yumrepo['influxdata'] -> Package[$telegraf::package_name]
     }
     'Suse': {
       if $telegraf::manage_archive {

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -228,7 +228,6 @@ describe 'telegraf' do
         let(:pre_condition) do
           [
             'class {"telegraf": manage_repo => false}',
-            'class {"apt": }'
           ]
         end
 
@@ -237,7 +236,7 @@ describe 'telegraf' do
           when 'Debian'
             is_expected.to compile.with_all_deps
             is_expected.to contain_package('telegraf')
-            is_expected.to contain_class('apt::update')
+            is_expected.not_to contain_apt__source('influxdata')
           end
         end
       end
@@ -246,7 +245,6 @@ describe 'telegraf' do
         let(:pre_condition) do
           [
             'class {"telegraf": manage_repo => false}',
-            'yumrepo {"influxdata": }'
           ]
         end
 
@@ -255,6 +253,7 @@ describe 'telegraf' do
           when 'RedHat'
             is_expected.to compile.with_all_deps
             is_expected.to contain_package('telegraf')
+            is_expected.not_to contain_yumrepo('influxdata')
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

This patch moves the relationship between the `Yumrepo` and the `Package` resources into the same conditional block of where the `Yumrepo` is created. Thus it doesn't assume there's always a `Yumrepo[influxdata]` in the catalog, even if `manage_repo=>false`.