### PR TITLE
Add support for Darwin

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,9 @@
 # [*archive_location*]
 #   String. Alternate archive location. E.g. an interal mirror.
 #
+# [*archive_version*]
+#   String. Specify a telegraf archive version. E.g. 1.17.2.
+#
 # [*archive_install_dir*]
 #   String. Location to extract archive to must be an absolute path
 #
@@ -134,6 +137,7 @@ class telegraf (
   Boolean $manage_archive                        = $telegraf::params::manage_archive,
   Optional[String] $repo_location                = $telegraf::params::repo_location,
   Optional[String] $archive_location             = $telegraf::params::archive_location,
+  Optional[String[1]] $archive_version           = $telegraf::params::archive_version,
   Optional[String] $archive_install_dir          = $telegraf::params::archive_install_dir,
   Boolean $purge_config_fragments                = $telegraf::params::purge_config_fragments,
   String  $repo_type                             = $telegraf::params::repo_type,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,76 @@ class telegraf::install {
   assert_private()
 
   case $facts['os']['family'] {
+    'Darwin': {
+      if $telegraf::manage_archive {
+        if $telegraf::manage_user {
+          group { $telegraf::config_file_group:
+            ensure => present,
+          }
+
+          user { $telegraf::config_file_owner:
+            ensure => present,
+            gid    => $telegraf::config_file_group,
+          }
+        }
+
+        $install_dir_deps = [
+          '/usr/local/bin',
+          '/usr/local/etc',
+          '/usr/local/opt',
+          '/usr/local/var',
+          '/usr/local/var/log',
+        ]
+
+        file { $install_dir_deps:
+          ensure => directory,
+        }
+
+        file { "${telegraf::archive_install_dir}-${telegraf::archive_version}":
+          ensure  => directory,
+          owner   => $telegraf::config_file_owner,
+          group   => $telegraf::config_file_group,
+          require => File[$install_dir_deps],
+        }
+
+        archive { "/tmp/telegraf-${telegraf::archive_version}.tar.gz":
+          ensure          => present,
+          extract         => true,
+          extract_path    => "${telegraf::archive_install_dir}-${telegraf::archive_version}",
+          extract_command => 'tar xfz %s --strip-components=2',
+          source          => "https://dl.influxdata.com/telegraf/releases/telegraf-${telegraf::archive_version}_darwin_amd64.tar.gz",
+          creates         => "${telegraf::archive_install_dir}-${$telegraf::archive_version}/usr/bin/telegraf",
+          user            => $telegraf::config_file_owner,
+          group           => $telegraf::config_file_group,
+          cleanup         => true,
+          require         => File["${telegraf::archive_install_dir}-${telegraf::archive_version}"],
+        }
+
+        file {
+          default:
+            ensure  => link,
+            require => Archive["/tmp/telegraf-${telegraf::archive_version}.tar.gz"],
+            ;
+          '/usr/local/bin/telegraf':
+            target  => "${telegraf::archive_install_dir}-${telegraf::archive_version}/usr/bin/telegraf",
+            ;
+          '/usr/local/etc/telegraf':
+            target  => "${telegraf::archive_install_dir}-${telegraf::archive_version}/etc/telegraf",
+            ;
+          '/usr/local/var/log/telegraf':
+            target  => "${telegraf::archive_install_dir}-${telegraf::archive_version}/var/log/telegraf",
+            ;
+        }
+
+        file { '/Library/LaunchDaemons/telegraf.plist':
+          ensure  => file,
+          content => epp('telegraf/telegraf.plist.epp', {
+              'config_file_owner' => $telegraf::config_file_owner,
+              'config_file_group' => $telegraf::config_file_group,
+          }),
+        }
+      }
+    }
     'Debian': {
       if $telegraf::manage_repo {
         if $facts['os']['name'] == 'Raspbian' {
@@ -91,7 +161,7 @@ class telegraf::install {
       # repo is not applicable to windows
     }
     default: {
-      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu and Windows repositories and Suse archives are supported at this time')
+      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu, Darwin and Windows repositories and Suse archives are supported at this time')
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,26 @@
 #
 class telegraf::params {
   case $facts['os']['family'] {
+    'Darwin': {
+      $config_file          = '/usr/local/etc/telegraf/telegraf.conf'
+      $config_file_owner    = 'telegraf'
+      $config_file_group    = 'telegraf'
+      $config_file_mode     = '0640'
+      $config_folder        = '/usr/local/etc/telegraf/telegraf.d'
+      $config_folder_mode   = '0770'
+      $logfile              = '/usr/local/var/log/telegraf/telegraf.log'
+      $manage_repo          = false
+      $manage_archive       = true
+      $manage_user          = true
+      $archive_install_dir  = '/usr/local/opt/telegraf'
+      $archive_version      = '1.17.2'
+      $archive_location     = "https://dl.influxdata.com/telegraf/releases/telegraf-${archive_version}_darwin_amd64.tar.gz"
+      $repo_location        = 'https://repos.influxdata.com/'
+      $service_enable       = true
+      $service_ensure       = running
+      $service_hasstatus    = true
+      $service_restart      = 'pkill -HUP telegraf'
+    }
     'windows': {
       $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
       $config_file_owner    = 'Administrator'
@@ -17,6 +37,7 @@ class telegraf::params {
       $manage_user          = false
       $archive_install_dir  = undef
       $archive_location     = undef
+      $archive_version      = undef
       $repo_location        = undef
       $service_enable       = true
       $service_ensure       = running
@@ -35,7 +56,8 @@ class telegraf::params {
       $manage_archive       = true
       $manage_user          = true
       $archive_install_dir  = '/opt/telegraf'
-      $archive_location     = 'https://dl.influxdata.com/telegraf/releases/telegraf-1.15.2_linux_amd64.tar.gz'
+      $archive_version      = '1.15.2'
+      $archive_location     = "https://dl.influxdata.com/telegraf/releases/telegraf-${archive_version}_linux_amd64.tar.gz"
       $repo_location        = 'https://repos.influxdata.com/'
       $service_enable       = true
       $service_ensure       = running
@@ -55,6 +77,7 @@ class telegraf::params {
       $manage_user          = false
       $archive_install_dir  = undef
       $archive_location     = undef
+      $archive_version      = undef
       $repo_location        = 'https://repos.influxdata.com/'
       $service_enable       = true
       $service_ensure       = running

--- a/metadata.json
+++ b/metadata.json
@@ -67,6 +67,12 @@
       "operatingsystemrelease": [
         "12"
       ]
+    },
+    {
+      "operatingsystem": "Darwin",
+      "operatingsystemrelease": [
+        "18"
+      ]
     }
   ],
   "dependencies": [

--- a/spec/defines/aggregator_spec.rb
+++ b/spec/defines/aggregator_spec.rb
@@ -24,6 +24,8 @@ describe 'telegraf::aggregator' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end

--- a/spec/defines/input_spec.rb
+++ b/spec/defines/input_spec.rb
@@ -21,6 +21,8 @@ describe 'telegraf::input' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -67,6 +69,8 @@ describe 'telegraf::input' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -104,6 +108,8 @@ describe 'telegraf::input' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -29,6 +29,8 @@ describe 'telegraf::processor' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -77,6 +79,8 @@ describe 'telegraf::processor' do
         case facts[:kernel]
         when 'windows'
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
+        when 'Darwin'
+          let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end

--- a/spec/hieradata/test/darwin.yaml
+++ b/spec/hieradata/test/darwin.yaml
@@ -1,0 +1,3 @@
+---
+telegraf::archive_install_dir: '/usr/local/opt/telegraf'
+telegraf::archive_version: '1.17.2'

--- a/templates/telegraf.plist.epp
+++ b/templates/telegraf.plist.epp
@@ -1,0 +1,36 @@
+<%- | String $config_file_owner,
+      String $config_file_group
+| -%>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>Label</key>
+    <string>telegraf</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/telegraf</string>
+      <string>-config</string>
+      <string>/usr/local/etc/telegraf/telegraf.conf</string>
+      <string>-config-directory</string>
+      <string>/usr/local/etc/telegraf/telegraf.d</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>WorkingDirectory</key>
+    <string>/usr/local/var/log/telegraf</string>
+    <key>StandardErrorPath</key>
+    <string>/usr/local/var/log/telegraf/telegraf.log</string>
+    <key>StandardOutPath</key>
+    <string>/usr/local/var/log/telegraf/telegraf.log</string>
+    <key>UserName</key>
+    <string><%= $config_file_owner %></string>
+    <key>GroupName</key>
+    <string><%= $config_file_group %></string>
+  </dict>
+</plist>


### PR DESCRIPTION
This adds support for Darwin 18 & 19 (macOS 10.14 and macOS 10.15). Only 18 is included in the metadata for testing because the next release of [facterdb](https://github.com/camptocamp/facterdb) should include a new set of facts for Darwin 19.

Please let me know what you think and if you would like to see any changes or have suggestions.

I'm currently investigating how to add acceptance tests for macos using GitHub Actions.

Thanks!