### PR TITLE
Update install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -99,8 +99,8 @@ class telegraf::install {
             'source' => "${telegraf::repo_location}influxdb.key",
           },
         }
+        Class['apt::update'] -> Package[$telegraf::package_name]
       }
-      Class['apt::update'] -> Package[$telegraf::package_name]
     }
     'RedHat': {
       if $telegraf::manage_repo {
@@ -117,8 +117,8 @@ class telegraf::install {
           gpgkey   => "${telegraf::repo_location}influxdb.key",
           gpgcheck => 1,
         }
+        Yumrepo['influxdata'] -> Package[$telegraf::package_name]
       }
-      Yumrepo['influxdata'] -> Package[$telegraf::package_name]
     }
     'Suse': {
       if $telegraf::manage_archive {


### PR DESCRIPTION
dependency between apt/yum repo and the telegraf package should only be made when manage_repo=true in install.pp

otherwise puppet will complain, because it cannot find the repository.

#### Pull Request (PR) description
<!--
dependency between apt/yum repo and the telegraf package should only be made when manage_repo=true in install.pp

otherwise puppet will complain, because it cannot find the repository.
-->

#### This Pull Request (PR) fixes the following issues
puppet throws an error of repository is not managed by the install pp, because of a failed dependency between the yum/apt repository and the telegraf package
