### PR TITLE
Configure processors via Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,16 @@ telegraf::outputs:
       database: 'influxdb'
       username: 'telegraf'
       password: 'telegraf'
+telegraf::processors:
+  replace_disk_type:
+    plugin_type: regex
+    options:
+      - namepass: ['diskio']
+        order: 1
+        tags:
+          - key: 'disk_type'
+            pattern: '^dos$'
+            replacement: 'FAT'
 ```
 
 `telegraf::inputs` accepts a hash of any inputs that you'd like to configure. However, you can also optionally define individual inputs using the `telegraf::input` type - this suits installations where, for example, a core module sets the defaults and other modules import it.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,8 @@
 # [*global_tags*]
 #   Hash.  Global tags as a key-value pair.
 #
+# @param processors Specify processors and their configuration.
+#
 # [*manage_service*]
 #   Boolean.  Whether to manage the telegraf service or not.
 #
@@ -132,6 +134,7 @@ class telegraf (
   Hash    $inputs                                = $telegraf::params::inputs,
   Hash    $outputs                               = $telegraf::params::outputs,
   Hash    $global_tags                           = $telegraf::params::global_tags,
+  Hash    $processors                            = {},
   Boolean $manage_service                        = $telegraf::params::manage_service,
   Boolean $manage_repo                           = $telegraf::params::manage_repo,
   Boolean $manage_archive                        = $telegraf::params::manage_archive,
@@ -162,6 +165,12 @@ class telegraf (
   contain telegraf::install
   contain telegraf::config
   contain telegraf::service
+
+  $processors.each |$processor, $attributes| {
+    telegraf::processor { $processor:
+      * => $attributes,
+    }
+  }
 
   Class['telegraf::install'] -> Class['telegraf::config'] ~> Class['telegraf::service']
   Class['telegraf::install'] ~> Class['telegraf::service']

--- a/spec/hieradata/test/telegraf.yaml
+++ b/spec/hieradata/test/telegraf.yaml
@@ -61,3 +61,13 @@ telegraf::outputs:
       database: 'telegraf'
       username: 'telegraf'
       password: 'telegraf'
+telegraf::processors:
+  rename_processor:
+    plugin_type: rename
+    options:
+      - order: 1
+        namepass: ['diskio']
+        replace:
+          tag: foo
+          dest: bar
+


### PR DESCRIPTION
This PR adds support for passing processors config via `telegraf::processors`

```
---
telegraf::processors:
  processor_name:
     plugin_type: rename
     options:
         - ...
```