### PR TITLE
Add FreeBSD support, using telegraf as installed by pkg(8)

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -162,8 +162,11 @@ class telegraf::install {
     'windows': {
       # repo is not applicable to windows
     }
+    'FreeBSD': {
+      # repo is not applicable to windows
+    }
     default: {
-      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu, Darwin and Windows repositories and Suse archives are supported at this time')
+      fail('Only RedHat, CentOS, OracleLinux, Debian, Ubuntu, Darwin, FreeBSD and Windows repositories and Suse archives are supported at this time')
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,26 @@ class telegraf::params {
       $service_hasstatus    = true
       $service_restart      = 'pkill -HUP telegraf'
     }
+    'FreeBSD': {
+      $config_file          = '/usr/local/etc/telegraf.conf'
+      $config_file_owner    = 'telegraf'
+      $config_file_group    = 'telegraf'
+      $config_file_mode     = '0640'
+      $config_folder        = '/usr/local/etc/telegraf.d'
+      $config_folder_mode   = '0770'
+      $logfile              = '/var/log/telegraf/telegraf.log'
+      $manage_repo          = false
+      $manage_archive       = false
+      $manage_user          = false
+      $archive_install_dir  = undef
+      $archive_version      = undef
+      $archive_location     = undef
+      $repo_location        = undef
+      $service_enable       = true
+      $service_ensure       = running
+      $service_hasstatus    = true
+      $service_restart      = 'pkill -HUP -j none telegraf'
+    }
     'windows': {
       $config_file          = 'C:/Program Files/telegraf/telegraf.conf'
       $config_file_owner    = 'Administrator'

--- a/metadata.json
+++ b/metadata.json
@@ -74,6 +74,13 @@
       "operatingsystemrelease": [
         "18"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "12",
+        "13"
+      ]
     }
   ],
   "dependencies": [

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -104,6 +104,13 @@ describe 'telegraf' do
             archive_version: '1.17.2'
           )
         end
+      when 'FreeBSD'
+        it do
+          is_expected.to contain_class('telegraf').with(
+            config_file_mode: '0640',
+            config_folder_mode: '0770'
+          )
+        end
       when 'Suse'
         it do
           is_expected.to contain_class('telegraf').with(
@@ -144,6 +151,12 @@ describe 'telegraf' do
         it { is_expected.to contain_file('/usr/local/etc/telegraf/telegraf.conf') }
         it {
           is_expected.to contain_file('/usr/local/etc/telegraf/telegraf.d').
+            with_purge(false)
+        }
+      when 'FreeBSD'
+        it { is_expected.to contain_file('/usr/local/etc/telegraf.conf') }
+        it {
+          is_expected.to contain_file('/usr/local/etc/telegraf.d').
             with_purge(false)
         }
       else
@@ -276,6 +289,8 @@ describe 'telegraf' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf'
+                when 'FreeBSD'
+                  '/usr/local/etc'
                 when 'windows'
                   'C:/Program Files/telegraf'
                 else

--- a/spec/defines/aggregator_spec.rb
+++ b/spec/defines/aggregator_spec.rb
@@ -26,6 +26,8 @@ describe 'telegraf::aggregator' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -59,6 +61,8 @@ describe 'telegraf::aggregator' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else
@@ -88,6 +92,8 @@ describe 'telegraf::aggregator' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else

--- a/spec/defines/input_spec.rb
+++ b/spec/defines/input_spec.rb
@@ -23,6 +23,8 @@ describe 'telegraf::input' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -71,6 +73,8 @@ describe 'telegraf::input' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -110,6 +114,8 @@ describe 'telegraf::input' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -142,6 +148,8 @@ describe 'telegraf::input' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else
@@ -171,6 +179,8 @@ describe 'telegraf::input' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else

--- a/spec/defines/output_spec.rb
+++ b/spec/defines/output_spec.rb
@@ -23,6 +23,8 @@ describe 'telegraf::output' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -55,6 +57,8 @@ describe 'telegraf::output' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else
@@ -84,6 +88,8 @@ describe 'telegraf::output' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else

--- a/spec/defines/processor_spec.rb
+++ b/spec/defines/processor_spec.rb
@@ -31,6 +31,8 @@ describe 'telegraf::processor' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -81,6 +83,8 @@ describe 'telegraf::processor' do
           let(:filename) { "C:/Program Files/telegraf/telegraf.d/#{title}.conf" }
         when 'Darwin'
           let(:filename) { "/usr/local/etc/telegraf/telegraf.d/#{title}.conf" }
+        when 'FreeBSD'
+          let(:filename) { "/usr/local/etc/telegraf.d/#{title}.conf" }
         else
           let(:filename) { "/etc/telegraf/telegraf.d/#{title}.conf" }
         end
@@ -119,6 +123,8 @@ describe 'telegraf::processor' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else
@@ -148,6 +154,8 @@ describe 'telegraf::processor' do
           dir = case facts[:osfamily]
                 when 'Darwin'
                   '/usr/local/etc/telegraf/telegraf.d'
+                when 'FreeBSD'
+                  '/usr/local/etc/telegraf.d'
                 when 'windows'
                   'C:/Program Files/telegraf/telegraf.d'
                 else


### PR DESCRIPTION
#### Pull Request (PR) description

This adds support for FreeBSD, using telegraf as installed by pkg(8). 
Where applicable, spec logic from Darwin support was used. 
FreeBSD's telegraf is in the package collection and needs no repository management.


#### This Pull Request (PR) fixes the following issues
n/a
