### PR TITLE
Add support for archive install on EL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,9 @@
 # [*manage_archive*]
 #   Boolean.  Whether or not to manage InfluxData's tar archive.
 #
+# @param manage_user
+#   Whether or not to manage the 'telegraf' user when installing from archive.
+#
 # [*repo_location*]
 #   String. Alternate repo location. E.g. an interal mirror.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,6 +138,7 @@ class telegraf (
   Boolean $manage_service                        = $telegraf::params::manage_service,
   Boolean $manage_repo                           = $telegraf::params::manage_repo,
   Boolean $manage_archive                        = $telegraf::params::manage_archive,
+  Boolean $manage_user                           = $telegraf::params::manage_user,
   Optional[String] $repo_location                = $telegraf::params::repo_location,
   Optional[String] $archive_location             = $telegraf::params::archive_location,
   Optional[String[1]] $archive_version           = $telegraf::params::archive_version,


### PR DESCRIPTION
This PR allows for installing from an archive source on EL.  It also exposes the `manage_user` parameter, which was previously only defined in `params.pp`.