### PR TITLE
Always install from the stable release class on Debian and Ubuntu

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -85,22 +85,12 @@ class telegraf::install {
     }
     'Debian': {
       if $telegraf::manage_repo {
-        if $facts['os']['name'] == 'Raspbian' {
-          $distro = $facts['os']['family'].downcase
-        } else {
-          $distro = $facts['os']['name'].downcase
-        }
-        if $facts.dig('os','distro','codename') {
-          $release = $facts['os']['distro']['codename']
-        } else {
-          $release = $facts['os']['lsb']['codename']
-        }
         apt::source { 'influxdata':
           ensure   => $telegraf::ensure_status,
           comment  => 'Mirror for InfluxData packages',
-          location => "${telegraf::repo_location}${distro}",
-          release  => $release,
-          repos    => $telegraf::repo_type,
+          location => "${telegraf::repo_location}debian",
+          release  => 'stable',
+          repos    => 'main',
           key      => {
             'id'     => '9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E',
             'source' => "${telegraf::repo_location}influxdata-archive_compat.key",


### PR DESCRIPTION
#### Pull Request (PR) description

InfluxData have added the release class "stable" to their DEB repository recently and consequently have stopped shipping builds specifically for Debian 12 ("Bookworm"):

https://repos.influxdata.com/debian/dists/

According to the docs in the above URL, using the stable release class is the new preferred way to install Telegraf et al.

#### This Pull Request (PR) fixes the following issues

Fixes #198