### PR TITLE
Relax version constraint for puppetlabs-stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -101,7 +101,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 8.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-apt",


### PR DESCRIPTION
#### Pull Request (PR) description

This PR relaxes the version constraint for `puppetlabs-stdlib` to `>= 8.1.0` so that it is easier to use the module in Puppet environments with modules that explicitly depend on `< 9`.

#### This Pull Request (PR) fixes the following issues

Fixes #219 
