### PR TITLE
puppet/archive: Allow 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -108,7 +108,7 @@
     },
     {
       "name": "puppet-archive",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 4.0.0 < 9.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
#### Pull Request (PR) description

Support the latest version of puppet-archive https://github.com/voxpupuli/puppet-archive, by allowing the version requirement to be higher than 8.x
