### PR TITLE
Apt: Write repo key to own file; require puppetlabs/apt 10.X

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -92,7 +92,7 @@ class telegraf::install {
           release  => 'stable',
           repos    => 'main',
           key      => {
-            'id'     => '9D539D90D3328DC7D6C8D3B9D8FF8E1F7DF8B07E',
+            'name'   => 'influxdata-archive.key',
             'source' => "${telegraf::repo_location}influxdata-archive_compat.key",
           },
         }

--- a/metadata.json
+++ b/metadata.json
@@ -104,7 +104,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 2.0.0 < 11.0.0"
+      "version_requirement": ">= 10.0.0 < 11.0.0"
     },
     {
       "name": "puppet-archive",


### PR DESCRIPTION
Without setting the name attribute, the key will be added to the global
/etc/apt/trusted.gpg keyring. That is deprecated. Also we need to ensure
`id` isn't set, otherwise apt-key might be invoked to fetch the key from
a keyserver.

Fixes #241