### PR TITLE
Default 'options' of input result in incorrect config

### DIFF
--- a/manifests/input.pp
+++ b/manifests/input.pp
@@ -7,7 +7,7 @@
 #
 define telegraf::input (
   String $plugin_type               = $name,
-  Array  $options                   = [],
+  Optional[Array]  $options         = undef,
   Enum['present', 'absent'] $ensure = 'present',
 ) {
   include telegraf


### PR DESCRIPTION
If you were to specify an input without any configuration using `telegraf::input`, the resulting telegraf config file has an incorrect format:

```
  telegraf::input { 'mem':
    plugin_type => 'mem',
  }
```

results in the following `mem.conf` being created:

```
[inputs]
mem = []
```

This is not a valid telegraf config and it will fail on this.

Similar to `output.pp` and `aggregator.pp`, `input.pp` now uses a default `undef` value for `options`, which does result in a correct config.