### PR TITLE
Update install.pp to include customizable RPM source

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -108,9 +108,16 @@ class telegraf::install {
     'RedHat': {
       if $telegraf::manage_repo {
         if $facts['os']['name'] == 'Amazon' {
-          $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${telegraf::repo_type}"
+          case $facts['os']['release']['major'] {
+            '2023': {
+              $_baseurl = "${telegraf::repo_location}rhel/9/\$basearch/${telegraf::repo_type}"
+            }
+            default: {
+              $_baseurl = "${telegraf::repo_location}rhel/6/\$basearch/${telegraf::repo_type}"
+            }
+          }
         } else {
-          $_baseurl = "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${telegraf::repo_type}"
+          $_baseurl = "${telegraf::repo_location}rhel/\$releasever/\$basearch/${telegraf::repo_type}"
         }
         yumrepo { 'influxdata':
           ensure   => $telegraf::ensure_status,


### PR DESCRIPTION
#### Pull Request (PR) description
The current managed install of telegraf's RPM repo is hard coded, and doesn't use the existing customizable URL.
Also update for Amazon 2023 to use RHEL9 as a base instead of 6 per https://docs.aws.amazon.com/linux/al2023/ug/relationship-to-fedora.html
