### PR TITLE
Mac Updates, Security Hardening

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -31,6 +31,7 @@ The following parameters are available in the `telegraf` class:
 
 * [`package_name`](#-telegraf--package_name)
 * [`ensure`](#-telegraf--ensure)
+* [`daemon_user`](#-telegraf--daemon_user)
 * [`config_file`](#-telegraf--config_file)
 * [`logfile`](#-telegraf--logfile)
 * [`logfile_rotation_interval`](#-telegraf--logfile_rotation_interval)
@@ -87,6 +88,14 @@ Data type: `String`
 State of the telegraf package. You can also specify a particular version to install
 
 Default value: `$telegraf::params::ensure`
+
+##### <a name="-telegraf--daemon_user"></a>`daemon_user`
+
+Data type: `String`
+
+User to run the daemon
+
+Default value: `$telegraf::params::daemon_user`
 
 ##### <a name="-telegraf--config_file"></a>`config_file`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,13 +48,13 @@ class telegraf::config inherits telegraf {
 
   if $telegraf::logfile {
     $log_directory_name = dirname($telegraf::logfile)
-  }
 
-  file { $log_directory_name:
-    owner => $telegraf::config_file_owner,
-    group => $telegraf::config_file_group,
-    mode  => $telegraf::config_folder_mode,
-    *     => $_dir,
+    file { $log_directory_name:
+      owner => $telegraf::config_file_owner,
+      group => $telegraf::config_file_group,
+      mode  => $telegraf::config_folder_mode,
+      *     => $_dir,
+    }
   }
 
   if $facts['os']['family'] == 'Darwin' {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -45,4 +45,30 @@ class telegraf::config inherits telegraf {
     recurse => true,
     *       => $_dir,
   }
+
+  if $telegraf::logfile {
+    $log_directory_name = dirname($telegraf::logfile)
+  }
+
+  file { $log_directory_name:
+    owner => $telegraf::config_file_owner,
+    group => $telegraf::config_file_group,
+    mode  => $telegraf::config_folder_mode,
+    *     => $_dir,
+  }
+
+  if $facts['os']['family'] == 'Darwin' {
+    file { '/Library/LaunchDaemons/telegraf.plist':
+      ensure  => $telegraf::ensure_file,
+      content => epp('telegraf/telegraf.plist.epp', {
+        'config_file_owner'  => $telegraf::config_file_owner,
+        'config_file_group'  => $telegraf::config_file_group,
+        'config_file'        => $telegraf::config_file,
+        'config_folder'      => $telegraf::config_folder,
+        'logfile'            => $telegraf::logfile,
+        'log_directory_name' => $log_directory_name,
+        'daemon_user'        => $telegraf::daemon_user
+      }),
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@
 #
 # @param package_name Package name
 # @param ensure State of the telegraf package. You can also specify a particular version to install
+# @param daemon_user User to run the daemon
 # @param config_file Path to the configuration file
 # @param logfile Path to the log file
 # @param logfile_rotation_interval The logfile will be rotated after the time interval specified, e.g. "1d". 0 = off. Default = "0h"
@@ -47,6 +48,7 @@
 class telegraf (
   String  $package_name                          = $telegraf::params::package_name,
   String  $ensure                                = $telegraf::params::ensure,
+  String  $daemon_user                           = $telegraf::params::daemon_user,
   String  $config_file                           = $telegraf::params::config_file,
   String  $config_file_owner                     = $telegraf::params::config_file_owner,
   String  $config_file_group                     = $telegraf::params::config_file_group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,75 +8,49 @@ class telegraf::install {
 
   case $facts['os']['family'] {
     'Darwin': {
+      if $telegraf::manage_user {
+        group { $telegraf::config_file_group:
+          ensure => present,
+        }
+
+        user { $telegraf::daemon_user:
+          ensure => present,
+          gid    => $telegraf::config_file_group,
+        }
+      }
+
       if $telegraf::manage_archive {
-        if $telegraf::manage_user {
-          group { $telegraf::config_file_group:
-            ensure => present,
-          }
-
-          user { $telegraf::config_file_owner:
-            ensure => present,
-            gid    => $telegraf::config_file_group,
-          }
-        }
-
-        $install_dir_deps = [
-          '/usr/local/bin',
-          '/usr/local/etc',
-          '/usr/local/opt',
-          '/usr/local/var',
-          '/usr/local/var/log',
-        ]
-
-        file { $install_dir_deps:
-          ensure => directory,
-        }
-
         file { "${telegraf::archive_install_dir}-${telegraf::archive_version}":
-          ensure  => directory,
-          owner   => $telegraf::config_file_owner,
-          group   => $telegraf::config_file_group,
-          require => File[$install_dir_deps],
+          ensure => directory,
+          owner  => $telegraf::config_file_owner,
+          group  => $telegraf::config_file_group,
         }
 
-        archive { "/tmp/telegraf-${telegraf::archive_version}.tar.gz":
+        -> archive { "/tmp/telegraf-${telegraf::archive_version}.tar.gz":
           ensure          => present,
           extract         => true,
           extract_path    => "${telegraf::archive_install_dir}-${telegraf::archive_version}",
           extract_command => 'tar xfz %s --strip-components=2',
           source          => "https://dl.influxdata.com/telegraf/releases/telegraf-${telegraf::archive_version}_darwin_amd64.tar.gz",
-          creates         => "${telegraf::archive_install_dir}-${$telegraf::archive_version}/usr/bin/telegraf",
+          creates         => "${telegraf::archive_install_dir}-${telegraf::archive_version}/usr/bin/telegraf",
           user            => $telegraf::config_file_owner,
           group           => $telegraf::config_file_group,
           cleanup         => true,
-          require         => File["${telegraf::archive_install_dir}-${telegraf::archive_version}"],
         }
 
-        file {
-          default:
-            ensure  => link,
-            require => Archive["/tmp/telegraf-${telegraf::archive_version}.tar.gz"],
-          ;
-          '/usr/local/bin/telegraf':
-            target  => "${telegraf::archive_install_dir}-${telegraf::archive_version}/usr/bin/telegraf",
-          ;
-          '/usr/local/etc/telegraf':
-            target => "${telegraf::archive_install_dir}-${telegraf::archive_version}/etc/telegraf",
-          ;
-          '/usr/local/var/log/telegraf':
-            target => "${telegraf::archive_install_dir}-${telegraf::archive_version}/var/log/telegraf",
-          ;
+        -> file { '/usr/local/bin/telegraf':
+          ensure => link,
+          target => "${telegraf::archive_install_dir}-${telegraf::archive_version}/usr/bin/telegraf",
         }
-
-        file { '/Library/LaunchDaemons/telegraf.plist':
-          ensure  => file,
-          content => epp('telegraf/telegraf.plist.epp', {
-            'config_file_owner' => $telegraf::config_file_owner,
-            'config_file_group' => $telegraf::config_file_group,
-          }),
+      } else {
+        package { $telegraf::package_name:
+          ensure          => $telegraf::ensure,
+          provider        => 'homebrew',
+          install_options => $telegraf::install_options,
         }
       }
-      elsif $telegraf::manage_repo {
+
+      if $telegraf::manage_repo {
         notify { 'telegraf repo warn':
           message  => "Installing from repo on ${facts['os']['name']} is not supported",
           loglevel => 'warning',
@@ -106,6 +80,16 @@ class telegraf::install {
       }
     }
     'RedHat': {
+      if $telegraf::manage_user {
+        group { $telegraf::config_file_group:
+          ensure => present,
+        }
+        user { $telegraf::daemon_user:
+          ensure => present,
+          gid    => $telegraf::config_file_group,
+        }
+      }
+
       if $telegraf::manage_repo {
         if $facts['os']['name'] == 'Amazon' {
           $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${telegraf::repo_type}"
@@ -140,27 +124,24 @@ class telegraf::install {
         file { '/etc/telegraf':
           ensure => directory,
         }
-        if $telegraf::manage_user {
-          group { $telegraf::config_file_group:
-            ensure => present,
-          }
-          user { $telegraf::config_file_owner:
-            ensure => present,
-            gid    => $telegraf::config_file_group,
-          }
-        }
+
         file { '/etc/systemd/system/telegraf.service':
           ensure => file,
           source => 'puppet:///modules/telegraf/telegraf.service',
         }
-        file { '/var/log/telegraf':
-          ensure => directory,
-          owner  => $telegraf::config_file_owner,
-          group  => $telegraf::config_file_group,
-        }
       }
     }
     'Suse': {
+      if $telegraf::manage_user {
+        group { $telegraf::config_file_group:
+          ensure => present,
+        }
+        user { $telegraf::daemon_user:
+          ensure => present,
+          gid    => $telegraf::config_file_group,
+        }
+      }
+
       if $telegraf::manage_archive {
         file { $telegraf::archive_install_dir:
           ensure => directory,
@@ -178,23 +159,10 @@ class telegraf::install {
         file { '/etc/telegraf':
           ensure => directory,
         }
-        if $telegraf::manage_user {
-          group { $telegraf::config_file_group:
-            ensure => present,
-          }
-          user { $telegraf::config_file_owner:
-            ensure => present,
-            gid    => $telegraf::config_file_group,
-          }
-        }
+
         file { '/etc/systemd/system/telegraf.service':
           ensure => file,
           source => 'puppet:///modules/telegraf/telegraf.service',
-        }
-        file { '/var/log/telegraf':
-          ensure => directory,
-          owner  => $telegraf::config_file_owner,
-          group  => $telegraf::config_file_group,
         }
       }
       elsif $telegraf::manage_repo {
@@ -205,7 +173,16 @@ class telegraf::install {
       }
     }
     'windows': {
-      # repo is not applicable to windows
+      # required to install telegraf on windows
+      require chocolatey
+
+      # package install
+      package { $telegraf::package_name:
+        ensure          => $telegraf::ensure,
+        provider        => chocolatey,
+        source          => $telegraf::windows_package_url,
+        install_options => $telegraf::install_options,
+      }
     }
     'FreeBSD': {
       # repo is not applicable to windows
@@ -215,25 +192,12 @@ class telegraf::install {
     }
   }
 
-  if $facts['os']['family'] == 'windows' {
-    # required to install telegraf on windows
-    require chocolatey
-
-    # package install
-    package { $telegraf::package_name:
-      ensure          => $telegraf::ensure,
-      provider        => chocolatey,
-      source          => $telegraf::windows_package_url,
-      install_options => $telegraf::install_options,
-    }
-  } else {
-    if ! $telegraf::manage_archive {
-      stdlib::ensure_packages([$telegraf::package_name],
-        {
-          ensure          => $telegraf::ensure,
-          install_options => $telegraf::install_options,
-        }
-      )
-    }
+  unless $telegraf::manage_archive {
+    stdlib::ensure_packages([$telegraf::package_name],
+      {
+        ensure          => $telegraf::ensure,
+        install_options => $telegraf::install_options,
+      }
+    )
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,6 +51,7 @@ class telegraf::params {
       $config_file_owner    = 'Administrator'
       $config_file_group    = 'Administrators'
       $config_file_mode     = undef
+      $daemon_user          = ''
       $config_folder        = 'C:/Program Files/telegraf/telegraf.d'
       $config_folder_mode   = undef
       $logfile              = 'C:/Program Files/telegraf/telegraf.log'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,13 +5,14 @@
 class telegraf::params {
   case $facts['os']['family'] {
     'Darwin': {
-      $config_file          = '/usr/local/etc/telegraf/telegraf.conf'
-      $config_file_owner    = 'telegraf'
+      $config_file          = '/usr/local/etc/telegraf.conf'
+      $config_file_owner    = 'root'
       $config_file_group    = 'telegraf'
       $config_file_mode     = '0640'
-      $config_folder        = '/usr/local/etc/telegraf/telegraf.d'
+      $config_folder        = '/usr/local/etc/telegraf.d'
       $config_folder_mode   = '0770'
-      $logfile              = '/usr/local/var/log/telegraf/telegraf.log'
+      $daemon_user          = 'telegraf'
+      $logfile              = '/var/log/telegraf/telegraf.log'
       $manage_repo          = false
       $manage_archive       = true
       $manage_user          = true
@@ -26,11 +27,12 @@ class telegraf::params {
     }
     'FreeBSD': {
       $config_file          = '/usr/local/etc/telegraf.conf'
-      $config_file_owner    = 'telegraf'
+      $config_file_owner    = 'root'
       $config_file_group    = 'telegraf'
       $config_file_mode     = '0640'
       $config_folder        = '/usr/local/etc/telegraf.d'
       $config_folder_mode   = '0770'
+      $daemon_user          = 'telegraf'
       $logfile              = '/var/log/telegraf/telegraf.log'
       $manage_repo          = false
       $manage_archive       = false
@@ -66,19 +68,19 @@ class telegraf::params {
     }
     'Suse': {
       $config_file          = '/etc/telegraf/telegraf.conf'
-      $config_file_owner    = 'telegraf'
+      $config_file_owner    = 'root'
       $config_file_group    = 'telegraf'
       $config_file_mode     = '0640'
       $config_folder        = '/etc/telegraf/telegraf.d'
       $config_folder_mode   = '0770'
-      $logfile              = ''
+      $daemon_user          = 'telegraf'
+      $logfile              = '/var/log/telegraf/telegraf.log'
       $manage_repo          = false
       $manage_archive       = true
       $manage_user          = true
       $archive_install_dir  = '/opt/telegraf'
       $archive_version      = '1.29.4'
       $archive_location     = "https://dl.influxdata.com/telegraf/releases/telegraf-${archive_version}_linux_amd64.tar.gz"
-      $repo_location        = 'https://repos.influxdata.com/'
       $service_enable       = true
       $service_ensure       = running
       $service_hasstatus    = true
@@ -86,12 +88,13 @@ class telegraf::params {
     }
     default: {
       $config_file          = '/etc/telegraf/telegraf.conf'
-      $config_file_owner    = 'telegraf'
+      $config_file_owner    = 'root'
       $config_file_group    = 'telegraf'
       $config_file_mode     = '0640'
       $config_folder        = '/etc/telegraf/telegraf.d'
       $config_folder_mode   = '0770'
-      $logfile              = ''
+      $daemon_user          = 'telegraf'
+      $logfile              = '/var/log/telegraf/telegraf.log'
       $manage_repo          = true
       $manage_archive       = false
       $manage_user          = false

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -202,12 +202,7 @@ describe 'telegraf' do
         it { is_expected.to contain_file('/etc/systemd/system/telegraf.service') }
       when 'Darwin'
         it { is_expected.to contain_archive('/tmp/telegraf-1.29.4.tar.gz') }
-        it { is_expected.to contain_file('/usr/local/bin').with_ensure('directory') }
-        it { is_expected.to contain_file('/usr/local/etc').with_ensure('directory') }
-        it { is_expected.to contain_file('/usr/local/opt').with_ensure('directory') }
-        it { is_expected.to contain_file('/usr/local/var').with_ensure('directory') }
-        it { is_expected.to contain_file('/usr/local/var/log').with_ensure('directory') }
-        it { is_expected.to contain_file('/usr/local/opt/telegraf-1.29.4').with_ensure('directory') }
+        it { is_expected.to contain_file('/usr/local/opt/telegraf').with_ensure('directory') }
         it { is_expected.to contain_file('/usr/local/var/log/telegraf').with_ensure('link') }
         it { is_expected.to contain_file('/usr/local/bin/telegraf').with_ensure('link') }
         it { is_expected.to contain_file('/usr/local/etc/telegraf').with_ensure('link') }

--- a/templates/telegraf.plist.epp
+++ b/templates/telegraf.plist.epp
@@ -1,5 +1,10 @@
 <%- | String $config_file_owner,
-      String $config_file_group
+      String $config_file_group,
+      String $config_file,
+      String $config_folder,
+      String $logfile,
+      String $log_directory_name,
+      String $daemon_user
 | -%>
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -16,20 +21,20 @@
     <array>
       <string>/usr/local/bin/telegraf</string>
       <string>-config</string>
-      <string>/usr/local/etc/telegraf/telegraf.conf</string>
+      <string><%= $config_file %></string>
       <string>-config-directory</string>
-      <string>/usr/local/etc/telegraf/telegraf.d</string>
+      <string><%= $config_folder %></string>
     </array>
     <key>RunAtLoad</key>
     <true/>
     <key>WorkingDirectory</key>
-    <string>/usr/local/var/log/telegraf</string>
+    <string><%= $log_directory_name %></string>
     <key>StandardErrorPath</key>
-    <string>/usr/local/var/log/telegraf/telegraf.log</string>
+    <string><%= $logfile %></string>
     <key>StandardOutPath</key>
-    <string>/usr/local/var/log/telegraf/telegraf.log</string>
+    <string><%= $logfile %></string>
     <key>UserName</key>
-    <string><%= $config_file_owner %></string>
+    <string><%= $daemon_user %></string>
     <key>GroupName</key>
     <string><%= $config_file_group %></string>
   </dict>


### PR DESCRIPTION
Darwin:
Support homebrew if provider is available.
Removed directories that are locally available by default to prevent conflicts with other modules.
Moved plist to config manifest (it's a config file)

General:
Moved management of the user/group outside of archive check block to allow management of the user without requiring archive.
Added daemon_user variable 
Security hardened config/log files by setting owner to root, group to telegraf with proper permissions.
Configuration files shouldn't be writable by the daemon using them.