### PR TITLE
Replace deprecated InfluxData repo signing key

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,7 +93,7 @@ class telegraf::install {
           repos    => 'main',
           key      => {
             'name'   => 'influxdata-archive.key',
-            'source' => "${telegraf::repo_location}influxdata-archive_compat.key",
+            'source' => "${telegraf::repo_location}influxdata-archive.key",
           },
         }
         Class['apt::update'] -> Package[$telegraf::package_name]
@@ -118,7 +118,7 @@ class telegraf::install {
           descr    => "InfluxData Repository - ${facts['os']['name']} \$releasever",
           enabled  => 1,
           baseurl  => $_baseurl,
-          gpgkey   => "${telegraf::repo_location}influxdata-archive_compat.key",
+          gpgkey   => "${telegraf::repo_location}influxdata-archive.key",
           gpgcheck => 1,
         }
         Yumrepo['influxdata'] -> Package[$telegraf::package_name]


### PR DESCRIPTION
InfluxData has deprecated the use of `influxdata-archive_compat.key`. All repositories should now use the new `influxdata-archive.key`.

InfluxData will rotate the signing key in early January 2026, which will remove support for the old compatibility key.

Documentation from InfluxData:
https://www.influxdata.com/blog/package-signing-key-rotation/