### PR TITLE
Fix Telegraf repo URL handling for RedHat hosts

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -107,17 +107,12 @@ class telegraf::install {
     }
     'RedHat': {
       if $telegraf::manage_repo {
-        if $facts['os']['name'] == 'Amazon' {
-          $_baseurl = "https://repos.influxdata.com/rhel/6/\$basearch/${telegraf::repo_type}"
-        } else {
-          $_baseurl = "https://repos.influxdata.com/rhel/\$releasever/\$basearch/${telegraf::repo_type}"
-        }
         yumrepo { 'influxdata':
           ensure   => $telegraf::ensure_status,
           name     => 'influxdata',
           descr    => "InfluxData Repository - ${facts['os']['name']} \$releasever",
           enabled  => 1,
-          baseurl  => $_baseurl,
+          baseurl  => "${telegraf::repo_location}${telegraf::repo_type}/\$basearch/main",
           gpgkey   => "${telegraf::repo_location}influxdata-archive.key",
           gpgcheck => 1,
         }

--- a/spec/classes/telegraf_spec.rb
+++ b/spec/classes/telegraf_spec.rb
@@ -222,7 +222,7 @@ describe 'telegraf' do
         it {
           is_expected.to contain_yumrepo('influxdata').
             with(
-              baseurl: 'https://repos.influxdata.com/rhel/$releasever/$basearch/stable'
+              baseurl: 'https://repos.influxdata.com/stable/$basearch/main'
             )
         }
       end
@@ -241,7 +241,7 @@ describe 'telegraf' do
           it {
             is_expected.to contain_yumrepo('influxdata').
               with(
-                baseurl: 'https://repos.influxdata.com/rhel/$releasever/$basearch/unstable'
+                baseurl: 'https://repos.influxdata.com/unstable/$basearch/main'
               )
           }
         end


### PR DESCRIPTION
Changes:
- Use `${telegraf::repo_location}` in baseurl
- Use [new baseurl scheme](https://docs.influxdata.com/telegraf/v1/install/?t=RedHat+%26amp%3B+CentOS#download-and-install-telegraf) for default RedHat hosts

--
This PR is based on the work by @alexeiser and his open PR: https://github.com/voxpupuli/puppet-telegraf/pull/250
Since I need the fixed usage of `${telegraf::repo_location}` rather quickly, I'll open this PR based on his works with the updated baseurl scheme.